### PR TITLE
Switch: Fix polylines

### DIFF
--- a/include/common/colors.h
+++ b/include/common/colors.h
@@ -10,6 +10,7 @@ struct ColorT
 
     ColorT() : r(0), g(0), b(0), a(0)
     {}
+
     ColorT(T r_, T g_, T b_, T a_) : r(r_), g(g_), b(b_), a(a_)
     {}
 

--- a/include/modules/graphics/graphics.h
+++ b/include/modules/graphics/graphics.h
@@ -578,6 +578,14 @@ namespace love
         static bool GetConstant(StackType in, const char*& out);
         static std::vector<const char*> GetConstants(StackType);
 
+        static bool GetConstant(const char* in, LineStyle& out);
+        static bool GetConstant(LineStyle in, const char*& out);
+        static std::vector<const char*> GetConstants(LineStyle);
+
+        static bool GetConstant(const char* in, LineJoin& out);
+        static bool GetConstant(LineJoin in, const char*& out);
+        static std::vector<const char*> GetConstants(LineJoin);
+
       protected:
         struct DisplayState
         {
@@ -642,5 +650,7 @@ namespace love
         const static StringMap<BlendAlpha, BLENDALPHA_MAX_ENUM> blendAlphaModes;
         const static StringMap<ArcMode, ARC_MAX_ENUM> arcModes;
         const static StringMap<StackType, STACK_MAX_ENUM> stackTypes;
+        const static StringMap<LineStyle, LINE_MAX_ENUM> lineStyles;
+        const static StringMap<LineJoin, LINE_JOIN_MAX_ENUM> lineJoins;
     };
 } // namespace love

--- a/include/modules/graphics/wrap_graphics.h
+++ b/include/modules/graphics/wrap_graphics.h
@@ -89,6 +89,10 @@ namespace Wrap_Graphics
 
     int SetLineWidth(lua_State* L);
 
+    int SetLineJoin(lua_State* L);
+
+    int SetLineStyle(lua_State* L);
+
     int SetNewFont(lua_State* L);
 
     int SetFont(lua_State* L);
@@ -110,6 +114,10 @@ namespace Wrap_Graphics
     int GetFont(lua_State* L);
 
     int GetLineWidth(lua_State* L);
+
+    int GetLineJoin(lua_State* L);
+
+    int GetLineStyle(lua_State* L);
 
     int GetScissor(lua_State* L);
 

--- a/platform/switch/include/deko3d/deko.h
+++ b/platform/switch/include/deko3d/deko.h
@@ -143,7 +143,7 @@ class deko3d
 
     bool RenderPolygon(const vertex::Vertex* points, size_t count);
 
-    bool RenderPolyline(const vertex::Vertex* points, size_t count);
+    bool RenderPolyline(DkPrimitive mode, const vertex::Vertex* points, size_t count);
 
     bool RenderPoints(const vertex::Vertex* points, size_t count);
 

--- a/platform/switch/include/deko3d/graphics.h
+++ b/platform/switch/include/deko3d/graphics.h
@@ -65,6 +65,8 @@ namespace love::deko3d
 
         void Circle(DrawMode mode, float x, float y, float radius, int points) override;
 
+        void Polyline(const Vector2* points, size_t count);
+
         void Polygon(DrawMode mode, const Vector2* points, size_t size,
                      bool skipLastFilledVertex = true) override;
 

--- a/platform/switch/include/deko3d/vertex.h
+++ b/platform/switch/include/deko3d/vertex.h
@@ -11,7 +11,7 @@
 #include <span>
 
 using namespace love;
-#include "debug/logger.h"
+
 namespace vertex
 {
     struct Vertex
@@ -42,6 +42,14 @@ namespace vertex
         WINDING_CW,
         WINDING_CCW,
         WINDING_MAX_ENUM
+    };
+
+    enum class TriangleIndexMode
+    {
+        NONE,
+        STRIP,
+        FAN,
+        QUADS
     };
 
     static inline uint16_t normto16t(float in)

--- a/platform/switch/include/deko3d/vertex.h
+++ b/platform/switch/include/deko3d/vertex.h
@@ -11,7 +11,7 @@
 #include <span>
 
 using namespace love;
-
+#include "debug/logger.h"
 namespace vertex
 {
     struct Vertex
@@ -85,8 +85,8 @@ namespace vertex
     {
         Colorf color = colors[0];
 
-        size_t pointCount                = points.size();
-        std::unique_ptr<Vertex[]> result = std::make_unique<Vertex[]>(points.size());
+        size_t pointCount = points.size();
+        auto result       = std::make_unique<Vertex[]>(pointCount);
 
         size_t colorCount = colors.size();
 

--- a/platform/switch/include/deko3d/vertex.h
+++ b/platform/switch/include/deko3d/vertex.h
@@ -7,7 +7,6 @@
 #include "common/vector.h"
 
 #include <array>
-#include <assert.h>
 #include <memory>
 #include <span>
 
@@ -81,8 +80,8 @@ namespace vertex
         };
     } // namespace attributes
 
-    [[nodiscard]] std::unique_ptr<Vertex[]> GeneratePrimitiveFromVectors(std::span<Vector2> points,
-                                                                         std::span<Colorf> colors)
+    [[nodiscard]] static inline std::unique_ptr<Vertex[]> GeneratePrimitiveFromVectors(
+        std::span<Vector2> points, std::span<Colorf> colors)
     {
         Colorf color = colors[0];
 

--- a/platform/switch/include/polyline/beveljoin.h
+++ b/platform/switch/include/polyline/beveljoin.h
@@ -4,14 +4,13 @@
 
 namespace love
 {
-   /* A Polyline whose segments are connected by a sharp edge. */
-    class MiterJoinPolyline : public Polyline
+    class BevelJoinPolyline : public Polyline
     {
       public:
         void Render(const Vector2* coords, size_t count, float halfWidth, float pixelSize,
                     bool drawOverdraw)
         {
-            Polyline::Render(coords, count, 2 * count, halfWidth, pixelSize, drawOverdraw);
+            Polyline::Render(coords, count, 4 * count - 4, halfWidth, pixelSize, drawOverdraw);
         }
 
       protected:

--- a/platform/switch/include/polyline/beveljoin.h
+++ b/platform/switch/include/polyline/beveljoin.h
@@ -4,6 +4,10 @@
 
 namespace love
 {
+    /*
+    ** A Polyline whose segments
+    ** are connected by a flat edge.
+    */
     class BevelJoinPolyline : public Polyline
     {
       public:

--- a/platform/switch/include/polyline/common.h
+++ b/platform/switch/include/polyline/common.h
@@ -1,0 +1,11 @@
+/*
+** This code is mostly from LÖVE's actual source code for the Polyline header
+** and sources. However, it has been adapted to work with deko3d.
+**
+** Original code for Polyline, etc by Matthias Richter
+*/
+
+#include "polyline/polyline.h"
+#include "polyline/miterjoin.h"
+#include "polyline/beveljoin.h"
+#include "polyline/nonejoin.h"

--- a/platform/switch/include/polyline/miterjoin.h
+++ b/platform/switch/include/polyline/miterjoin.h
@@ -4,7 +4,10 @@
 
 namespace love
 {
-   /* A Polyline whose segments are connected by a sharp edge. */
+    /*
+    ** A Polyline whose segments
+    ** are connected by a sharp edge.
+    */
     class MiterJoinPolyline : public Polyline
     {
       public:

--- a/platform/switch/include/polyline/miterjoin.h
+++ b/platform/switch/include/polyline/miterjoin.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "polyline/polyline.h"
+
+namespace love
+{
+    class MiterJoinPolyline : public Polyline
+    {
+      public:
+        void Render(const Vector2* coords, size_t count, float halfWidth, float pixelSize,
+                    bool drawOverdraw)
+        {
+            Polyline::Render(coords, count, 2 * count, halfWidth, pixelSize, drawOverdraw);
+        }
+
+      protected:
+        void RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals, Vector2& s,
+                        float& len_s, Vector2& ns, const Vector2& q, const Vector2& r,
+                        float hw) override;
+    };
+} // namespace love

--- a/platform/switch/include/polyline/nonejoin.h
+++ b/platform/switch/include/polyline/nonejoin.h
@@ -7,7 +7,7 @@ namespace love
     class NoneJoinPolyline : public Polyline
     {
       public:
-        NoneJoinPolyline() : Polyline(DkPrimitive_QuadStrip)
+        NoneJoinPolyline() : Polyline(DkPrimitive_Quads)
         {}
 
         void Render(const Vector2* vertices, size_t count, float halfWidth, float pixelSize,
@@ -23,7 +23,7 @@ namespace love
             // get rasterized. These vertices are in between the core line vertices
             // and the overdraw vertices in the combined vertex array, so they still
             // get "rendered" since we draw everything with one draw call.
-            std::fill_n(this->vertices + (this->vertexCount - 4), sizeof(Vector2) * 4, Vector2{});
+            memset(&this->vertices[this->vertexCount - 4], 0, sizeof(Vector2) * 4);
 
             this->vertexCount -= 4;
         }

--- a/platform/switch/include/polyline/nonejoin.h
+++ b/platform/switch/include/polyline/nonejoin.h
@@ -4,11 +4,17 @@
 
 namespace love
 {
+    /*
+    ** A Polyline whose segments
+    ** are not connected.
+    */
     class NoneJoinPolyline : public Polyline
     {
       public:
-        NoneJoinPolyline() : Polyline(DkPrimitive_Quads)
-        {}
+        NoneJoinPolyline() : Polyline(vertex::TriangleIndexMode::QUADS)
+        {
+          this->triangleMode = DkPrimitive_Quads;
+        }
 
         void Render(const Vector2* vertices, size_t count, float halfWidth, float pixelSize,
                     bool drawOverdraw)

--- a/platform/switch/include/polyline/nonejoin.h
+++ b/platform/switch/include/polyline/nonejoin.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "polyline/polyline.h"
+
+namespace love
+{
+    class NoneJoinPolyline : public Polyline
+    {
+      public:
+        NoneJoinPolyline() : Polyline(DkPrimitive_QuadStrip)
+        {}
+
+        void Render(const Vector2* vertices, size_t count, float halfWidth, float pixelSize,
+                    bool drawOverdraw)
+        {
+            Polyline::Render(vertices, count, 4 * count - 4, halfWidth, pixelSize, drawOverdraw);
+
+            // discard the first and last two vertices. (these are redundant)
+            for (size_t i = 0; i < this->vertexCount - 4; ++i)
+                this->vertices[i] = this->vertices[i + 2];
+
+            // The last quad is now garbage, so zero it out to make sure it doesn't
+            // get rasterized. These vertices are in between the core line vertices
+            // and the overdraw vertices in the combined vertex array, so they still
+            // get "rendered" since we draw everything with one draw call.
+            std::fill_n(this->vertices + (this->vertexCount - 4), sizeof(Vector2) * 4, Vector2{});
+
+            this->vertexCount -= 4;
+        }
+
+      protected:
+        void CalculateOverdrawVertexCount(bool /* isLooping */) override;
+
+        void RenderOverdraw(const std::vector<Vector2>& normals, float pixelSize, bool isLooping) override;
+
+        void FillColorArray(Colorf constantColor, Colorf* colors, int count) override;
+
+        void RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals, Vector2& s, float& lengthS, Vector2& normalS, const Vector2& q, const Vector2& r, float halfWidth) override;
+    };
+} // namespace love

--- a/platform/switch/include/polyline/nonejoin.h
+++ b/platform/switch/include/polyline/nonejoin.h
@@ -23,7 +23,7 @@ namespace love
             // get rasterized. These vertices are in between the core line vertices
             // and the overdraw vertices in the combined vertex array, so they still
             // get "rendered" since we draw everything with one draw call.
-            memset(&this->vertices[this->vertexCount - 4], 0, sizeof(Vector2) * 4);
+            std::fill_n(this->vertices + (this->vertexCount - 4), 4, Vector2 {});
 
             this->vertexCount -= 4;
         }
@@ -31,10 +31,13 @@ namespace love
       protected:
         void CalculateOverdrawVertexCount(bool /* isLooping */) override;
 
-        void RenderOverdraw(const std::vector<Vector2>& normals, float pixelSize, bool isLooping) override;
+        void RenderOverdraw(const std::vector<Vector2>& normals, float pixelSize,
+                            bool isLooping) override;
 
         void FillColorArray(Colorf constantColor, Colorf* colors, int count) override;
 
-        void RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals, Vector2& s, float& lengthS, Vector2& normalS, const Vector2& q, const Vector2& r, float halfWidth) override;
+        void RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals, Vector2& s,
+                        float& lengthS, Vector2& normalS, const Vector2& q, const Vector2& r,
+                        float halfWidth) override;
     };
 } // namespace love

--- a/platform/switch/include/polyline/polyline.h
+++ b/platform/switch/include/polyline/polyline.h
@@ -7,15 +7,19 @@ namespace love
 {
     class Graphics;
 
+    /*
+    ** Abstract base class
+    ** for a chain of segments.
+    */
     class Polyline
     {
       public:
-        Polyline(DkPrimitive mode = DkPrimitive_TriangleStrip) :
+        Polyline(vertex::TriangleIndexMode mode = vertex::TriangleIndexMode::STRIP) :
             vertices(nullptr),
             overdraw(nullptr),
             vertexCount(0),
             overdrawVertexCount(0),
-            triangleMode(mode),
+            triangleIndexMode(mode),
             overdrawVertexStart(0)
         {}
 
@@ -67,7 +71,9 @@ namespace love
         size_t vertexCount;
         size_t overdrawVertexCount;
 
-        DkPrimitive triangleMode;
+        vertex::TriangleIndexMode triangleIndexMode;
         size_t overdrawVertexStart;
+
+        DkPrimitive triangleMode = DkPrimitive_TriangleStrip;
     };
 } // namespace love

--- a/platform/switch/include/polyline/polyline.h
+++ b/platform/switch/include/polyline/polyline.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "deko3d/vertex.h"
+#include <span>
+
+namespace love
+{
+    class Graphics;
+
+    class Polyline
+    {
+      public:
+        Polyline(DkPrimitive mode = DkPrimitive_TriangleStrip) :
+            vertices(nullptr),
+            overdraw(nullptr),
+            vertexCount(0),
+            overdrawVertexCount(0),
+            triangleMode(mode),
+            overdrawVertexStart(0)
+        {}
+
+        virtual ~Polyline();
+
+        /**
+         * @param coords      Vertices defining the core line segments
+         * @param count         Number of vertices
+         * @param size_hint     Expected number of vertices of the rendering sleeve around the core
+         * line.
+         * @param halfwidth     linewidth / 2.
+         * @param pixel_size    Dimension of one pixel on the screen in world coordinates.
+         * @param draw_overdraw Fake antialias the line.
+         */
+        void Render(const Vector2* coords, size_t count, size_t sizeHint, float halfWidth,
+                    float pixelSize, bool drawOverdraw);
+
+        void Draw(Graphics* graphics);
+
+      protected:
+        virtual void CalculateOverdrawVertexCount(bool isLooping);
+
+        virtual void RenderOverdraw(const std::vector<Vector2>& normals, float pixelSize,
+                                    bool isLooping);
+
+        virtual void FillColorArray(Color32 constant, Color32* colors, int count);
+
+        /** Calculate line boundary points.
+         *
+         * @param[out]    anchors Anchor points defining the core line.
+         * @param[out]    normals Normals defining the edge of the sleeve.
+         * @param[in,out] s       Direction of segment pq (updated to the segment qr).
+         * @param[in,out] len_s   Length of segment pq (updated to the segment qr).
+         * @param[in,out] ns      Normal on the segment pq (updated to the segment qr).
+         * @param[in]     q       Current point on the line.
+         * @param[in]     r       Next point on the line.
+         * @param[in]     hw      Half line width (see Polyline.render()).
+         */
+        virtual void RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals,
+                                Vector2& s, float& len_s, Vector2& ns, const Vector2& q,
+                                const Vector2& r, float hw) = 0;
+
+        static constexpr float LINES_PARALLEL_EPS = 0.05f;
+
+        Vector2* vertices;
+        Vector2* overdraw;
+
+        size_t vertexCount;
+        size_t overdrawVertexCount;
+
+        DkPrimitive triangleMode;
+        size_t overdrawVertexStart;
+    };
+} // namespace love

--- a/platform/switch/include/polyline/polyline.h
+++ b/platform/switch/include/polyline/polyline.h
@@ -41,7 +41,7 @@ namespace love
         virtual void RenderOverdraw(const std::vector<Vector2>& normals, float pixelSize,
                                     bool isLooping);
 
-        virtual void FillColorArray(Color32 constant, Color32* colors, int count);
+        virtual void FillColorArray(Colorf constant, Colorf* colors, int count);
 
         /** Calculate line boundary points.
          *

--- a/platform/switch/include/polyline/polyline.h
+++ b/platform/switch/include/polyline/polyline.h
@@ -41,6 +41,7 @@ namespace love
         virtual void RenderOverdraw(const std::vector<Vector2>& normals, float pixelSize,
                                     bool isLooping);
 
+        /* Enables a "fake" anti-aliasing line border */
         virtual void FillColorArray(Colorf constant, Colorf* colors, int count);
 
         /** Calculate line boundary points.

--- a/platform/switch/source/deko3d/deko.cpp
+++ b/platform/switch/source/deko3d/deko.cpp
@@ -401,7 +401,7 @@ bool deko3d::RenderTexture(const DkResHandle handle, const vertex::Vertex* point
     return true;
 }
 
-bool deko3d::RenderPolyline(const vertex::Vertex* points, size_t count)
+bool deko3d::RenderPolyline(DkPrimitive mode, const vertex::Vertex* points, size_t count)
 {
     if (count > (this->vtxRing.getSize() - this->firstVertex) || points == nullptr)
         return false;
@@ -410,7 +410,7 @@ bool deko3d::RenderPolyline(const vertex::Vertex* points, size_t count)
 
     memcpy(this->vertexData + this->firstVertex, points, count * sizeof(vertex::Vertex));
 
-    this->cmdBuf.draw(DkPrimitive_LineStrip, count, 1, this->firstVertex, 0);
+    this->cmdBuf.draw(mode, count, 1, this->firstVertex, 0);
 
     this->firstVertex += count;
 

--- a/platform/switch/source/deko3d/graphics.cpp
+++ b/platform/switch/source/deko3d/graphics.cpp
@@ -1,5 +1,7 @@
 #include "deko3d/graphics.h"
 
+#include "polyline/miterjoin.h"
+
 using namespace love;
 using Screen = love::Graphics::Screen;
 
@@ -264,28 +266,48 @@ Font* love::deko3d::Graphics::NewFont(Rasterizer* data, const Texture::Filter& f
 
 /* Primitives */
 
+void love::deko3d::Graphics::Polyline(const Vector2* points, size_t count)
+{
+    float halfwidth = this->GetLineWidth() * 0.5f;
+    float pixelsize = 1.0f / std::max((float)pixelScaleStack.back(), 0.000001f);
+
+    LineJoin linejoin   = this->GetLineJoin();
+    LineStyle linestyle = this->GetLineStyle();
+
+    if (linejoin == LINE_JOIN_MITER)
+    {
+        MiterJoinPolyline line;
+        line.Render(points, count, halfwidth, pixelsize, linestyle == LINE_SMOOTH);
+
+        line.Draw(this);
+    }
+}
+
 void love::deko3d::Graphics::Polygon(DrawMode mode, const Vector2* points, size_t count,
                                      bool skipLastVertex)
 {
-    Colorf color[1] = { this->GetColor() };
-
-    const Matrix4& t = this->GetTransform();
-    bool is2D        = t.IsAffine2DTransform();
-
-    const int vertexCount = (int)count - (mode == DRAW_FILL && skipLastVertex) ? 1 : 0;
-
-    Vector2 transformed[vertexCount];
-    std::fill_n(transformed, vertexCount, Vector2 {});
-
-    if (is2D)
-        t.TransformXY(transformed, points, vertexCount);
-
-    auto vertices = vertex::GeneratePrimitiveFromVectors(std::span(transformed, vertexCount), std::span(color, 1));
-
-    if (mode == DRAW_FILL)
-        ::deko3d::Instance().RenderPolygon(vertices.get(), vertexCount);
+    if (mode == DRAW_LINE)
+        this->Polyline(points, count);
     else
-        ::deko3d::Instance().RenderPolyline(vertices.get(), vertexCount);
+    {
+        Colorf color[1] = { this->GetColor() };
+
+        const Matrix4& t = this->GetTransform();
+        bool is2D        = t.IsAffine2DTransform();
+
+        int vertexCount = (int)count - ((skipLastVertex) ? 1 : 0);
+
+        Vector2 transformed[vertexCount];
+        std::fill_n(transformed, vertexCount, Vector2 {});
+
+        if (is2D)
+            t.TransformXY(transformed, points, vertexCount);
+
+        auto vertices = vertex::GeneratePrimitiveFromVectors(std::span(transformed, vertexCount),
+                                                             std::span(color, 1));
+
+        ::deko3d::Instance().RenderPolygon(vertices.get(), vertexCount);
+    }
 }
 
 void love::deko3d::Graphics::SetLineWidth(float width)
@@ -295,7 +317,7 @@ void love::deko3d::Graphics::SetLineWidth(float width)
 
 void love::deko3d::Graphics::Line(const Vector2* points, int count)
 {
-    this->Polygon(DRAW_LINE, points, count);
+    this->Polyline(points, count);
 }
 
 void love::deko3d::Graphics::Rectangle(DrawMode mode, float x, float y, float width, float height)
@@ -512,7 +534,7 @@ void love::deko3d::Graphics::Points(const Vector2* points, size_t count, const C
     bool is2D        = t.IsAffine2DTransform();
 
     Vector2 transformed[count];
-    std::fill_n(transformed, count, Vector2{});
+    std::fill_n(transformed, count, Vector2 {});
 
     if (is2D)
         t.TransformXY(transformed, points, count);
@@ -520,7 +542,8 @@ void love::deko3d::Graphics::Points(const Vector2* points, size_t count, const C
     Colorf colorList[colorCount];
     memcpy(colorList, colors, colorCount);
 
-    auto vertices = vertex::GeneratePrimitiveFromVectors(std::span(transformed, count), std::span(colorList, colorCount));
+    auto vertices = vertex::GeneratePrimitiveFromVectors(std::span(transformed, count),
+                                                         std::span(colorList, colorCount));
 
     ::deko3d::Instance().RenderPoints(vertices.get(), count);
 }

--- a/platform/switch/source/deko3d/graphics.cpp
+++ b/platform/switch/source/deko3d/graphics.cpp
@@ -1,6 +1,6 @@
 #include "deko3d/graphics.h"
 
-#include "polyline/miterjoin.h"
+#include "polyline/common.h"
 
 using namespace love;
 using Screen = love::Graphics::Screen;
@@ -268,16 +268,32 @@ Font* love::deko3d::Graphics::NewFont(Rasterizer* data, const Texture::Filter& f
 
 void love::deko3d::Graphics::Polyline(const Vector2* points, size_t count)
 {
-    float halfwidth = this->GetLineWidth() * 0.5f;
-    float pixelsize = 1.0f / std::max((float)pixelScaleStack.back(), 0.000001f);
+    float halfWidth = this->GetLineWidth() * 0.5f;
+    float pixelSize = 1.0f / std::max((float)pixelScaleStack.back(), 0.000001f);
 
-    LineJoin linejoin   = this->GetLineJoin();
-    LineStyle linestyle = this->GetLineStyle();
+    LineJoin lineJoin   = this->GetLineJoin();
+    LineStyle lineStyle = this->GetLineStyle();
 
-    if (linejoin == LINE_JOIN_MITER)
+    bool drawOverdraw = (lineStyle == LINE_SMOOTH);
+
+    if (lineJoin == LINE_JOIN_NONE)
+    {
+        NoneJoinPolyline line;
+        line.Render(points, count, halfWidth, pixelSize, drawOverdraw);
+
+        line.Draw(this);
+    }
+    else if (lineJoin == LINE_JOIN_BEVEL)
+    {
+        BevelJoinPolyline line;
+        line.Render(points, count, halfWidth, pixelSize, drawOverdraw);
+
+        line.Draw(this);
+    }
+    else if (lineJoin == LINE_JOIN_MITER)
     {
         MiterJoinPolyline line;
-        line.Render(points, count, halfwidth, pixelsize, linestyle == LINE_SMOOTH);
+        line.Render(points, count, halfWidth, pixelSize, drawOverdraw);
 
         line.Draw(this);
     }
@@ -312,6 +328,7 @@ void love::deko3d::Graphics::Polygon(DrawMode mode, const Vector2* points, size_
 
 void love::deko3d::Graphics::SetLineWidth(float width)
 {
+    ::Graphics::SetLineWidth(width);
     ::deko3d::Instance().SetLineWidth(width);
 }
 

--- a/platform/switch/source/polyline/beveljoin.cpp
+++ b/platform/switch/source/polyline/beveljoin.cpp
@@ -1,0 +1,52 @@
+#include "polyline/beveljoin.h"
+
+using namespace love;
+
+void BevelJoinPolyline::RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals,
+                                   Vector2& s, float& len_s, Vector2& ns, const Vector2& q,
+                                   const Vector2& r, float hw)
+{
+    Vector2 t   = (r - q);
+    float len_t = t.getLength();
+
+    float det = Vector2::cross(s, t);
+    if (fabs(det) / (len_s * len_t) < Polyline::LINES_PARALLEL_EPS && Vector2::dot(s, t) > 0)
+    {
+        // lines parallel, compute as u1 = q + ns * w/2, u2 = q - ns * w/2
+        Vector2 n = t.getNormal(hw / len_t);
+        anchors.push_back(q);
+        anchors.push_back(q);
+        normals.push_back(n);
+        normals.push_back(-n);
+        s     = t;
+        len_s = len_t;
+        return; // early out
+    }
+
+    // cramers rule
+    Vector2 nt   = t.getNormal(hw / len_t);
+    float lambda = Vector2::cross((nt - ns), t) / det;
+    Vector2 d    = ns + s * lambda;
+
+    anchors.push_back(q);
+    anchors.push_back(q);
+    anchors.push_back(q);
+    anchors.push_back(q);
+    if (det > 0) // 'left' turn -> intersection on the top
+    {
+        normals.push_back(d);
+        normals.push_back(-ns);
+        normals.push_back(d);
+        normals.push_back(-nt);
+    }
+    else
+    {
+        normals.push_back(ns);
+        normals.push_back(-d);
+        normals.push_back(nt);
+        normals.push_back(-d);
+    }
+    s     = t;
+    len_s = len_t;
+    ns    = nt;
+}

--- a/platform/switch/source/polyline/miterjoin.cpp
+++ b/platform/switch/source/polyline/miterjoin.cpp
@@ -1,0 +1,35 @@
+#include "polyline/miterjoin.h"
+
+using namespace love;
+
+void MiterJoinPolyline::RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals,
+                                   Vector2& s, float& len_s, Vector2& ns, const Vector2& q,
+                                   const Vector2& r, float hw)
+{
+    Vector2 t   = (r - q);
+    float len_t = t.getLength();
+    Vector2 nt  = t.getNormal(hw / len_t);
+
+    anchors.push_back(q);
+    anchors.push_back(q);
+
+    float det = Vector2::cross(s, t);
+    if (fabs(det) / (len_s * len_t) < Polyline::LINES_PARALLEL_EPS && Vector2::dot(s, t) > 0)
+    {
+        // lines parallel, compute as u1 = q + ns * w/2, u2 = q - ns * w/2
+        normals.push_back(ns);
+        normals.push_back(-ns);
+    }
+    else
+    {
+        // cramers rule
+        float lambda = Vector2::cross((nt - ns), t) / det;
+        Vector2 d    = ns + s * lambda;
+        normals.push_back(d);
+        normals.push_back(-d);
+    }
+
+    s     = t;
+    ns    = nt;
+    len_s = len_t;
+}

--- a/platform/switch/source/polyline/nonejoin.cpp
+++ b/platform/switch/source/polyline/nonejoin.cpp
@@ -75,6 +75,6 @@ void NoneJoinPolyline::RenderEdge(std::vector<Vector2>& anchors, std::vector<Vec
 
     anchors.push_back(q);
     anchors.push_back(q);
-    normals.push_back(normalS);
     normals.push_back(-normalS);
+    normals.push_back(normalS);
 }

--- a/platform/switch/source/polyline/nonejoin.cpp
+++ b/platform/switch/source/polyline/nonejoin.cpp
@@ -15,7 +15,7 @@ void NoneJoinPolyline::FillColorArray(Colorf constant_color, Colorf* colors, int
     }
 }
 
-void NoneJoinPolyline::RenderOverdraw(const std::vector<Vector2>& /*normals*/, float pixel_size,
+void NoneJoinPolyline::RenderOverdraw(const std::vector<Vector2>& /*normals*/, float pixelSize,
                                       bool /*is_looping*/)
 {
     for (size_t i = 2; i + 3 < this->vertexCount; i += 4)
@@ -24,32 +24,33 @@ void NoneJoinPolyline::RenderOverdraw(const std::vector<Vector2>& /*normals*/, f
         // | / | <- main quad line
         // v1-v3
 
-        Vector2 s = vertices[i + 0] - vertices[i + 2];
-        Vector2 t = vertices[i + 0] - vertices[i + 1];
-        s.normalize(pixel_size);
-        t.normalize(pixel_size);
+        Vector2 s = this->vertices[i + 0] - this->vertices[i + 2];
+        Vector2 t = this->vertices[i + 0] - this->vertices[i + 1];
+
+        s.normalize(pixelSize);
+        t.normalize(pixelSize);
 
         const size_t k = 4 * (i - 2);
 
-        overdraw[k + 0] = vertices[i + 0];
-        overdraw[k + 1] = vertices[i + 1];
-        overdraw[k + 2] = vertices[i + 0] + s + t;
-        overdraw[k + 3] = vertices[i + 1] + s - t;
+        this->overdraw[k + 0] = this->vertices[i + 0];
+        this->overdraw[k + 1] = this->vertices[i + 1];
+        this->overdraw[k + 2] = this->vertices[i + 0] + s + t;
+        this->overdraw[k + 3] = this->vertices[i + 1] + s - t;
 
-        overdraw[k + 4] = vertices[i + 1];
-        overdraw[k + 5] = vertices[i + 3];
-        overdraw[k + 6] = vertices[i + 1] + s - t;
-        overdraw[k + 7] = vertices[i + 3] - s - t;
+        this->overdraw[k + 4] = this->vertices[i + 1];
+        this->overdraw[k + 5] = this->vertices[i + 3];
+        this->overdraw[k + 6] = this->vertices[i + 1] + s - t;
+        this->overdraw[k + 7] = this->vertices[i + 3] - s - t;
 
-        overdraw[k + 8]  = vertices[i + 3];
-        overdraw[k + 9]  = vertices[i + 2];
-        overdraw[k + 10] = vertices[i + 3] - s - t;
-        overdraw[k + 11] = vertices[i + 2] - s + t;
+        this->overdraw[k + 8]  = this->vertices[i + 3];
+        this->overdraw[k + 9]  = this->vertices[i + 2];
+        this->overdraw[k + 10] = this->vertices[i + 3] - s - t;
+        this->overdraw[k + 11] = this->vertices[i + 2] - s + t;
 
-        overdraw[k + 12] = vertices[i + 2];
-        overdraw[k + 13] = vertices[i + 0];
-        overdraw[k + 14] = vertices[i + 2] - s + t;
-        overdraw[k + 15] = vertices[i + 0] + s + t;
+        this->overdraw[k + 12] = this->vertices[i + 2];
+        this->overdraw[k + 13] = this->vertices[i + 0];
+        this->overdraw[k + 14] = this->vertices[i + 2] - s + t;
+        this->overdraw[k + 15] = this->vertices[i + 0] + s + t;
     }
 }
 

--- a/platform/switch/source/polyline/nonejoin.cpp
+++ b/platform/switch/source/polyline/nonejoin.cpp
@@ -1,0 +1,79 @@
+#include "polyline/nonejoin.h"
+
+void NoneJoinPolyline::CalculateOverdrawVertexCount(bool /* isLooping */)
+{
+    this->overdrawVertexCount = 4 * (this->vertexCount - 2);
+}
+
+void NoneJoinPolyline::FillColorArray(Colorf constant_color, Colorf* colors, int count)
+{
+    for (int i = 0; i < count; ++i)
+    {
+        Colorf c = constant_color;
+        c.a *= (i & 3) < 2; // if (i % 4 == 2 || i % 4 == 3) c.a = 0
+        colors[i] = c;
+    }
+}
+
+void NoneJoinPolyline::RenderOverdraw(const std::vector<Vector2>& /*normals*/, float pixel_size,
+                                      bool /*is_looping*/)
+{
+    for (size_t i = 2; i + 3 < this->vertexCount; i += 4)
+    {
+        // v0-v2
+        // | / | <- main quad line
+        // v1-v3
+
+        Vector2 s = vertices[i + 0] - vertices[i + 2];
+        Vector2 t = vertices[i + 0] - vertices[i + 1];
+        s.normalize(pixel_size);
+        t.normalize(pixel_size);
+
+        const size_t k = 4 * (i - 2);
+
+        overdraw[k + 0] = vertices[i + 0];
+        overdraw[k + 1] = vertices[i + 1];
+        overdraw[k + 2] = vertices[i + 0] + s + t;
+        overdraw[k + 3] = vertices[i + 1] + s - t;
+
+        overdraw[k + 4] = vertices[i + 1];
+        overdraw[k + 5] = vertices[i + 3];
+        overdraw[k + 6] = vertices[i + 1] + s - t;
+        overdraw[k + 7] = vertices[i + 3] - s - t;
+
+        overdraw[k + 8]  = vertices[i + 3];
+        overdraw[k + 9]  = vertices[i + 2];
+        overdraw[k + 10] = vertices[i + 3] - s - t;
+        overdraw[k + 11] = vertices[i + 2] - s + t;
+
+        overdraw[k + 12] = vertices[i + 2];
+        overdraw[k + 13] = vertices[i + 0];
+        overdraw[k + 14] = vertices[i + 2] - s + t;
+        overdraw[k + 15] = vertices[i + 0] + s + t;
+    }
+}
+
+void NoneJoinPolyline::RenderEdge(std::vector<Vector2>& anchors, std::vector<Vector2>& normals,
+                                  Vector2& s, float& lengthS, Vector2& normalS, const Vector2& q,
+                                  const Vector2& r, float halfWidth)
+{
+    //   ns1------ns2
+    //    |        |
+    //    q ------ r
+    //    |        |
+    // (-ns1)----(-ns2)
+
+    anchors.push_back(q);
+    anchors.push_back(q);
+    normals.push_back(normalS);
+    normals.push_back(-normalS);
+
+    s       = (r - q);
+    lengthS = s.getLength();
+    normalS = s.getNormal(halfWidth / lengthS);
+
+    anchors.push_back(q);
+    anchors.push_back(q);
+    normals.push_back(normalS);
+    normals.push_back(-normalS);
+}

--- a/platform/switch/source/polyline/polyline.cpp
+++ b/platform/switch/source/polyline/polyline.cpp
@@ -1,0 +1,207 @@
+#include "polyline/polyline.h"
+#include "modules/graphics/graphics.h"
+
+#include "deko3d/deko.h"
+
+#include <algorithm>
+
+using namespace love;
+
+Polyline::~Polyline()
+{
+    if (this->vertices)
+        delete[] this->vertices;
+}
+
+void Polyline::CalculateOverdrawVertexCount(bool isLooping)
+{
+    this->overdrawVertexCount = 2 * this->vertexCount + (isLooping ? 0 : 2);
+}
+
+void Polyline::FillColorArray(Color32 constantColor, Color32* colors, int count)
+{
+    for (int i = 0; i < count; ++i)
+    {
+        Color32 color = constantColor;
+        color.a *= (i + 1) % 2; // avoids branching. equiv to if (i%2 == 1) c.a = 0;
+
+        colors[i] = color;
+    }
+}
+
+void Polyline::Render(const Vector2* coords, size_t count, size_t sizeHint, float halfWidth,
+                      float pixelSize, bool drawOverdraw)
+{
+    static std::vector<Vector2> anchors;
+    anchors.clear();
+    anchors.reserve(sizeHint);
+
+    static std::vector<Vector2> normals;
+    normals.clear();
+    normals.reserve(sizeHint);
+
+    /* prepare vertex arrays */
+    if (drawOverdraw)
+        halfWidth -= pixelSize * 0.3f;
+
+    /* compute sleeve */
+    bool isLooping = (coords[0] == coords[count - 1]);
+
+    Vector2 s;
+    if (!isLooping)
+        s = coords[1] - coords[0];
+    else
+        s = coords[0] - coords[count - 2];
+
+    float lenS = s.getLength();
+    Vector2 nS = s.getNormal(halfWidth / lenS);
+
+    Vector2 q, r(coords[0]);
+    for (size_t i = 0; i < count; i++)
+    {
+        q = r;
+        r = coords[i + 1];
+
+        this->RenderEdge(anchors, normals, s, lenS, nS, q, r, halfWidth);
+    }
+
+    q = r;
+    r = isLooping ? coords[1] : r + s;
+    this->RenderEdge(anchors, normals, s, lenS, nS, q, r, halfWidth);
+
+    /* set vertex count */
+    this->vertexCount = normals.size();
+
+    size_t extraVertices = 0;
+    if (drawOverdraw)
+    {
+        this->CalculateOverdrawVertexCount(isLooping);
+
+        if (triangleMode == DkPrimitive_TriangleStrip)
+            extraVertices = 2;
+    }
+
+    this->vertices = new Vector2[this->vertexCount + extraVertices + this->overdrawVertexCount];
+
+    for (size_t i = 0; i < this->vertexCount; ++i)
+        this->vertices[i] = anchors[i] + normals[i];
+
+    if (drawOverdraw)
+    {
+        this->overdraw            = this->vertices + vertexCount + extraVertices;
+        this->overdrawVertexCount = this->vertexCount + extraVertices;
+
+        this->RenderOverdraw(normals, pixelSize, isLooping);
+    }
+
+    if (extraVertices)
+    {
+        this->vertices[vertexCount + 0] = this->vertices[this->vertexCount - 1];
+        this->vertices[vertexCount + 1] = this->vertices[this->overdrawVertexStart];
+    }
+}
+
+void Polyline::RenderOverdraw(const std::vector<Vector2>& normals, float pixelSize, bool isLooping)
+{
+    // upper segment
+    for (size_t i = 0; i + 1 < this->vertexCount; i += 2)
+    {
+        this->overdraw[i] = this->vertices[i];
+        this->overdraw[i + 1] =
+            this->vertices[i] + normals[i] * (pixelSize / normals[i].getLength());
+    }
+    // lower segment
+    for (size_t i = 0; i + 1 < this->vertexCount; i += 2)
+    {
+        size_t k = this->vertexCount - i - 1;
+
+        this->overdraw[this->vertexCount + i] = vertices[k];
+        this->overdraw[this->vertexCount + i + 1] =
+            vertices[k] + normals[k] * (pixelSize / normals[k].getLength());
+    }
+
+    // if not looping, the outer overdraw vertices need to be displaced
+    // to cover the line endings, i.e.:
+    // +- - - - //- - +         +- - - - - //- - - +
+    // +-------//-----+         : +-------//-----+ :
+    // | core // line |   -->   : | core // line | :
+    // +-----//-------+         : +-----//-------+ :
+    // +- - //- - - - +         +- - - //- - - - - +
+    if (!isLooping)
+    {
+        // left edge
+        Vector2 spacer = (this->overdraw[1] - this->overdraw[3]);
+        spacer.normalize(pixelSize);
+        this->overdraw[1] += spacer;
+        this->overdraw[this->overdrawVertexCount - 3] += spacer;
+
+        // right edge
+        spacer = (this->overdraw[this->vertexCount - 1] - this->overdraw[this->vertexCount - 3]);
+        spacer.normalize(pixelSize);
+
+        this->overdraw[this->vertexCount - 1] += spacer;
+        this->overdraw[this->vertexCount + 1] += spacer;
+
+        // we need to draw two more triangles to close the
+        // overdraw at the line start.
+        this->overdraw[this->overdrawVertexCount - 2] = this->overdraw[0];
+        this->overdraw[this->overdrawVertexCount - 1] = this->overdraw[1];
+    }
+}
+
+#include "debug/logger.h"
+void Polyline::Draw(Graphics* graphics)
+{
+    const Matrix4& t = graphics->GetTransform();
+    bool is2D        = t.IsAffine2DTransform();
+
+    Colorf colors[1] = { graphics->GetColor() };
+
+    int overdrawStart = (int)this->overdrawVertexStart;
+    int overdrawCount = (int)this->overdrawVertexCount;
+
+    int totalVertexCount = (int)this->vertexCount;
+
+    if (this->overdraw)
+        totalVertexCount = overdrawStart + overdrawCount;
+
+    int maxVertices = std::numeric_limits<uint16_t>::max() - 3;
+    int advance     = maxVertices;
+
+    if (this->triangleMode == DkPrimitive_TriangleStrip)
+        advance -= 2;
+
+    for (int vertexStart = 0; vertexStart < totalVertexCount; vertexStart += advance)
+    {
+        const Vector2* verts = this->vertices + vertexStart;
+        int cmdVertexCount   = std::min(maxVertices, totalVertexCount - vertexStart);
+
+        std::unique_ptr<Vector2[]> transformed = std::make_unique<Vector2[]>(cmdVertexCount);
+
+        if (is2D)
+            t.TransformXY(transformed.get(), verts, cmdVertexCount);
+
+        int drawRoughCount = std::min((int)this->vertexCount, (int)this->vertexCount - vertexStart);
+
+        auto render = vertex::GeneratePrimitiveFromVectors(
+            std::span(transformed.get(), drawRoughCount), std::span(colors, 1));
+
+        if (this->overdraw)
+        {
+            int drawRemainingCount = cmdVertexCount - drawRoughCount;
+
+            int drawOverdrawBegin = overdrawStart - vertexStart;
+            int drawOverdrawEnd   = drawOverdrawBegin + overdrawCount;
+
+            drawOverdrawBegin = std::max(0, drawOverdrawBegin);
+
+            int drawOverdrawCount =
+                std::min(drawRemainingCount, drawOverdrawEnd - drawOverdrawBegin);
+
+            // if (drawOverdrawCount > 0)
+            //     continue;
+        }
+
+        ::deko3d::Instance().RenderPolyline(this->triangleMode, render.get(), cmdVertexCount);
+    }
+}

--- a/platform/switch/source/polyline/polyline.cpp
+++ b/platform/switch/source/polyline/polyline.cpp
@@ -77,7 +77,7 @@ void Polyline::Render(const Vector2* coords, size_t count, size_t sizeHint, floa
     {
         this->CalculateOverdrawVertexCount(isLooping);
 
-        if (triangleMode == DkPrimitive_TriangleStrip)
+        if (this->triangleIndexMode == vertex::TriangleIndexMode::STRIP)
             extraVertices = 2;
     }
 
@@ -168,7 +168,7 @@ void Polyline::Draw(Graphics* graphics)
     int maxVertices = std::numeric_limits<uint16_t>::max() - 3;
     int advance     = maxVertices;
 
-    if (this->triangleMode == DkPrimitive_TriangleStrip)
+    if (this->triangleIndexMode == vertex::TriangleIndexMode::STRIP)
         advance -= 2;
 
     for (int vertexStart = 0; vertexStart < totalVertexCount; vertexStart += advance)

--- a/source/modules/graphics/graphicsc.cpp
+++ b/source/modules/graphics/graphicsc.cpp
@@ -626,6 +626,36 @@ std::vector<const char*> Graphics::GetConstants(StackType)
     return stackTypes.GetNames();
 }
 
+bool Graphics::GetConstant(const char* in, LineJoin& out)
+{
+    return lineJoins.Find(in, out);
+}
+
+bool Graphics::GetConstant(LineJoin in, const char*& out)
+{
+    return lineJoins.Find(in, out);
+}
+
+std::vector<const char*> Graphics::GetConstants(LineJoin)
+{
+    return lineJoins.GetNames();
+}
+
+bool Graphics::GetConstant(const char* in, LineStyle& out)
+{
+    return lineStyles.Find(in, out);
+}
+
+bool Graphics::GetConstant(LineStyle in, const char*& out)
+{
+    return lineStyles.Find(in, out);
+}
+
+std::vector<const char*> Graphics::GetConstants(LineStyle)
+{
+    return lineStyles.GetNames();
+}
+
 // clang-format off
 constexpr StringMap<Graphics::BlendMode, Graphics::BLEND_MAX_ENUM>::Entry blendModeEntries[] =
 {
@@ -674,4 +704,21 @@ constexpr StringMap<Graphics::StackType, Graphics::STACK_MAX_ENUM>::Entry stackT
 };
 
 constinit const StringMap<Graphics::StackType, Graphics::STACK_MAX_ENUM> Graphics::stackTypes(stackTypeEntries);
+
+constexpr StringMap<Graphics::LineJoin, Graphics::LINE_JOIN_MAX_ENUM>::Entry lineJoinEntries[] =
+{
+    { "none",  Graphics::LINE_JOIN_NONE  },
+    { "miter", Graphics::LINE_JOIN_MITER },
+    { "bevel", Graphics::LINE_JOIN_BEVEL }
+};
+
+constinit const StringMap<Graphics::LineJoin, Graphics::LINE_JOIN_MAX_ENUM> Graphics::lineJoins(lineJoinEntries);
+
+constexpr StringMap<Graphics::LineStyle, Graphics::LINE_MAX_ENUM>::Entry lineStyleEntries[] =
+{
+    { "smooth", Graphics::LINE_SMOOTH },
+    { "rough",  Graphics::LINE_ROUGH  }
+};
+
+constinit const StringMap<Graphics::LineStyle, Graphics::LINE_MAX_ENUM> Graphics::lineStyles(lineStyleEntries);
 // clang-format on

--- a/source/modules/graphics/wrap_graphics.cpp
+++ b/source/modules/graphics/wrap_graphics.cpp
@@ -459,6 +459,58 @@ int Wrap_Graphics::Polygon(lua_State* L)
     return 0;
 }
 
+int Wrap_Graphics::SetLineJoin(lua_State* L)
+{
+    const char* str = luaL_checkstring(L, 1);
+
+    Graphics::LineJoin join;
+    if (!Graphics::GetConstant(str, join))
+        return Luax::EnumError(L, "line join", Graphics::GetConstants(join), str);
+
+    instance()->SetLineJoin(join);
+
+    return 0;
+}
+
+int Wrap_Graphics::GetLineJoin(lua_State* L)
+{
+    Graphics::LineJoin join = instance()->GetLineJoin();
+
+    const char* str = nullptr;
+    if (!Graphics::GetConstant(join, str))
+        return luaL_error(L, "Unknown line join");
+
+    lua_pushstring(L, str);
+
+    return 1;
+}
+
+int Wrap_Graphics::SetLineStyle(lua_State* L)
+{
+    const char* str = luaL_checkstring(L, 1);
+
+    Graphics::LineStyle style;
+    if (!Graphics::GetConstant(str, style))
+        return Luax::EnumError(L, "line style", Graphics::GetConstants(style), str);
+
+    instance()->SetLineStyle(style);
+
+    return 0;
+}
+
+int Wrap_Graphics::GetLineStyle(lua_State* L)
+{
+    Graphics::LineStyle style = instance()->GetLineStyle();
+
+    const char* str;
+    if (!Graphics::GetConstant(style, str))
+        return luaL_error(L, "Unknown line style");
+
+    lua_pushstring(L, str);
+
+    return 1;
+}
+
 int Wrap_Graphics::SetLineWidth(lua_State* L)
 {
     float width = luaL_checknumber(L, 1);
@@ -1172,6 +1224,8 @@ int Wrap_Graphics::Register(lua_State* L)
                          { "getDimensions", GetDimensions },
                          { "getFont", GetFont },
                          { "getHeight", GetHeight },
+                         { "getLineStyle", GetLineStyle },
+                         { "getLineJoin", GetLineJoin },
                          { "getLineWidth", GetLineWidth },
                          { "getPointSize", GetPointSize },
                          { "getRendererInfo", GetRendererInfo },
@@ -1205,6 +1259,8 @@ int Wrap_Graphics::Register(lua_State* L)
                          { "setCanvas", SetCanvas },
                          { "setColor", SetColor },
                          { "setDefaultFilter", SetDefaultFilter },
+                         { "setLineStyle", SetLineStyle },
+                         { "setLineJoin", SetLineJoin },
                          { "setLineWidth", SetLineWidth },
                          { "setNewFont", SetNewFont },
                          { "setPointSize", SetPointSize },


### PR DESCRIPTION
This fixes rendering polylines (any primitives rendered with the `line` mode) by taking into account the current line width. It also enables setting the line style to `smooth` or `rough` and the join type to `none`, `bevel`, or `miter`.