### PR TITLE
Switch Audio: Actually Fix Audio Issues

### DIFF
--- a/include/objects/source/sourcec.h
+++ b/include/objects/source/sourcec.h
@@ -8,12 +8,6 @@
 #include "modules/audio/pool/pool.h"
 #include "objects/object.h"
 
-#if defined(__SWITCH__)
-typedef AudioDriverWaveBuf _waveBuf;
-    #define LOVE_SetBufferLooping(waveBuf, loop) ((waveBuf).is_looping = (loop))
-    #define FlushAudioCache                      armDCacheFlush
-#endif
-
 namespace love
 {
     class StaticDataBuffer : public Object

--- a/platform/switch/include/driver/audiodrv.h
+++ b/platform/switch/include/driver/audiodrv.h
@@ -20,7 +20,7 @@ namespace love::driver
             return instance;
         }
 
-        void ResetChannel(size_t channel, int channels, PcmFormat format, int sampleRate);
+        bool ResetChannel(size_t channel, int channels, PcmFormat format, int sampleRate);
 
         void SetMixVolume(int mix, float volume);
 
@@ -28,11 +28,9 @@ namespace love::driver
 
         bool IsChannelPlaying(size_t channel);
 
-        void AddWaveBufStream(size_t channel, AudioDriverWaveBuf* waveBuf);
-
-        void AddWaveBuf(size_t channel, AudioDriverWaveBuf* waveBuf);
-
         bool IsChannelPaused(size_t channel);
+
+        bool AddWaveBuf(size_t channel, AudioDriverWaveBuf* waveBuf);
 
         void PauseChannel(size_t channel, bool pause);
 
@@ -48,6 +46,8 @@ namespace love::driver
         thread::MutexRef mutex;
 
         bool audioInitialized;
+        bool channelReset;
+
         AudioDriver driver;
     };
 } // namespace love::driver

--- a/platform/switch/source/objects/source.cpp
+++ b/platform/switch/source/objects/source.cpp
@@ -97,9 +97,8 @@ void Source::SetVolume(float volume)
 void Source::Reset()
 {
     PcmFormat format = (this->bitDepth == 8) ? PcmFormat_Int8 : PcmFormat_Int16;
-    bool success     = driver::Audrv::Instance().ResetChannel(this->channel, this->channels,
-                                                          PcmFormat_Int16, this->sampleRate);
-    LOG("Reset successful: %d", success);
+    driver::Audrv::Instance().ResetChannel(this->channel, this->channels, PcmFormat_Int16,
+                                           this->sampleRate);
 }
 
 bool Source::Update()
@@ -213,9 +212,8 @@ bool Source::PlayAtomic()
     this->PrepareAtomic();
 
     /* add the initial wavebuffer */
-    driver::Audrv::Instance().StopChannel(this->channel);
-    bool success = driver::Audrv::Instance().AddWaveBuf(this->channel, &this->sources[0]);
-    LOG("Added Successfully: %d", success);
+    driver::Audrv::Instance().AddWaveBuf(this->channel, &this->sources[0]);
+
     if (this->sourceType != TYPE_STREAM)
         this->offsetSamples = 0;
 

--- a/platform/switch/source/objects/source.cpp
+++ b/platform/switch/source/objects/source.cpp
@@ -97,7 +97,9 @@ void Source::SetVolume(float volume)
 void Source::Reset()
 {
     PcmFormat format = (this->bitDepth == 8) ? PcmFormat_Int8 : PcmFormat_Int16;
-    driver::Audrv::Instance().ResetChannel(this->channel, this->channels, format, this->sampleRate);
+    bool success     = driver::Audrv::Instance().ResetChannel(this->channel, this->channels,
+                                                          PcmFormat_Int16, this->sampleRate);
+    LOG("Reset successful: %d", success);
 }
 
 bool Source::Update()
@@ -187,12 +189,7 @@ int Source::StreamAtomic(size_t which)
 
 bool Source::IsPlaying() const
 {
-    if (!this->valid)
-        return false;
-
-    bool playing = driver::Audrv::Instance().IsChannelPlaying(this->channel);
-
-    return playing;
+    return this->valid && !driver::Audrv::Instance().IsChannelPaused(this->channel);
 }
 
 bool Source::IsFinished() const
@@ -217,8 +214,8 @@ bool Source::PlayAtomic()
 
     /* add the initial wavebuffer */
     driver::Audrv::Instance().StopChannel(this->channel);
-    driver::Audrv::Instance().AddWaveBuf(this->channel, &this->sources[0]);
-
+    bool success = driver::Audrv::Instance().AddWaveBuf(this->channel, &this->sources[0]);
+    LOG("Added Successfully: %d", success);
     if (this->sourceType != TYPE_STREAM)
         this->offsetSamples = 0;
 

--- a/source/modules/audio/pool/poolc.cpp
+++ b/source/modules/audio/pool/poolc.cpp
@@ -12,7 +12,7 @@ Pool::Pool()
 
 Pool::~Pool()
 {
-    // Source::Stop(this);
+    Source::Stop(this);
 }
 
 int Pool::GetActiveSourceCount() const
@@ -64,7 +64,6 @@ bool Pool::AssignSource(common::Source* source, size_t& channel, char& wasPlayin
         return false;
 
     channel = this->available.front();
-    LOG("Assigned Channel #%zu", channel);
 
     this->available.pop();
 
@@ -102,8 +101,6 @@ bool Pool::ReleaseSource(common::Source* source, bool stop)
 
         this->available.push(channel);
         this->playing.erase(source);
-
-        LOG("Re-adding Channel #%zu", channel);
 
         return true;
     }

--- a/source/modules/audio/pool/poolc.cpp
+++ b/source/modules/audio/pool/poolc.cpp
@@ -22,7 +22,7 @@ int Pool::GetActiveSourceCount() const
 
 int Pool::GetMaxSources() const
 {
-    return 24;
+    return this->TOTAL_CHANNELS;
 }
 
 std::vector<common::Source*> Pool::GetPlayingSources()
@@ -64,6 +64,7 @@ bool Pool::AssignSource(common::Source* source, size_t& channel, char& wasPlayin
         return false;
 
     channel = this->available.front();
+    LOG("Assigned Channel #%zu", channel);
 
     this->available.pop();
 
@@ -98,9 +99,11 @@ bool Pool::ReleaseSource(common::Source* source, bool stop)
             source->StopAtomic();
 
         source->Release();
-        this->available.push(channel);
 
+        this->available.push(channel);
         this->playing.erase(source);
+
+        LOG("Re-adding Channel #%zu", channel);
 
         return true;
     }

--- a/source/objects/source/sourcec.cpp
+++ b/source/objects/source/sourcec.cpp
@@ -282,7 +282,7 @@ double Source::Tell(Source::Unit unit)
     else
         return offset;
 }
-#include "debug/logger.h"
+
 bool Source::Play(const std::vector<Source*>& sources)
 {
     if (sources.size() == 0)


### PR DESCRIPTION
The audio issues still persisted as it turns out. This will actually fix it.

Turns out that the way the Switch audio driver works is that "Voice ID"s have channels which make it stereo or mono. These get allocated based on our Source object's audio channels. Eventually they would get exhausted due to not getting free'd. 

The fix is simple: whenever a Source is destroyed, it is stopped and thusly now also calls audrvVoiceDrop which allows its Voice ID's allocated channels to be freed properly.

Thanks to @fincs for helping out and explaining the details!