### PR TITLE
getLanguage -> getPreferredLocales

### DIFF
--- a/include/modules/system/systemc.h
+++ b/include/modules/system/systemc.h
@@ -69,7 +69,7 @@ namespace love::common
 
         virtual const std::string& GetSystemTheme() = 0;
 
-        virtual const std::string& GetLanguage() = 0;
+        virtual const std::string& GetPreferredLocales() = 0;
 
         virtual const std::string& GetVersion() = 0;
 

--- a/include/modules/system/wrap_system.h
+++ b/include/modules/system/wrap_system.h
@@ -11,7 +11,7 @@ namespace Wrap_System
 
     int GetNetworkInfo(lua_State* L);
 
-    int GetLanguage(lua_State* L);
+    int GetPreferredLocales(lua_State* L);
 
     int GetRegion(lua_State* L);
 

--- a/platform/3ds/include/modules/system/system.h
+++ b/platform/3ds/include/modules/system/system.h
@@ -27,7 +27,7 @@ namespace love
 
         const std::string& GetSystemTheme() override;
 
-        const std::string& GetLanguage() override;
+        const std::string& GetPreferredLocales() override;
 
         const std::string& GetVersion() override;
 

--- a/platform/3ds/source/modules/system.cpp
+++ b/platform/3ds/source/modules/system.cpp
@@ -109,7 +109,7 @@ System::NetworkState System::GetNetworkInfo(uint8_t& signal) const
     return state;
 }
 
-const std::string& System::GetLanguage()
+const std::string& System::GetPreferredLocales()
 {
     if (!this->systemInfo.language.empty())
         return this->systemInfo.language;
@@ -234,18 +234,18 @@ void System::SetPlayCoins(int amount)
 
 // clang-format off
 constexpr auto languages = BidirectionalMap<>::Create(
-    "Japanese",            CFG_LANGUAGE_JP,
-    "English",             CFG_LANGUAGE_EN,
-    "French",              CFG_LANGUAGE_FR,
-    "German",              CFG_LANGUAGE_DE,
-    "Italian",             CFG_LANGUAGE_IT,
-    "Spanish",             CFG_LANGUAGE_ES,
-    "Simplified Chinese",  CFG_LANGUAGE_ZH,
-    "Korean",              CFG_LANGUAGE_KO,
-    "Dutch",               CFG_LANGUAGE_NL,
-    "Portugese",           CFG_LANGUAGE_PT,
-    "Russian",             CFG_LANGUAGE_RU,
-    "Traditional Chinese", CFG_LANGUAGE_TW
+    "jp",    CFG_LANGUAGE_JP,
+    "en",    CFG_LANGUAGE_EN,
+    "fr",    CFG_LANGUAGE_FR,
+    "de",    CFG_LANGUAGE_DE,
+    "it",    CFG_LANGUAGE_IT,
+    "es",    CFG_LANGUAGE_ES,
+    "zh_CN", CFG_LANGUAGE_ZH,
+    "ko",    CFG_LANGUAGE_KO,
+    "nl",    CFG_LANGUAGE_NL,
+    "pt",    CFG_LANGUAGE_PT,
+    "ru",    CFG_LANGUAGE_RU,
+    "zh_TW", CFG_LANGUAGE_TW
 );
 
 constexpr auto models = BidirectionalMap<>::Create(

--- a/platform/switch/include/modules/system/system.h
+++ b/platform/switch/include/modules/system/system.h
@@ -29,7 +29,7 @@ namespace love
 
         const std::string& GetSystemTheme() override;
 
-        const std::string& GetLanguage() override;
+        const std::string& GetPreferredLocales() override;
 
         const std::string& GetModel() override;
 

--- a/platform/switch/source/modules/system.cpp
+++ b/platform/switch/source/modules/system.cpp
@@ -79,7 +79,7 @@ System::NetworkState System::GetNetworkInfo(uint8_t& signal) const
     return state;
 }
 
-const std::string& System::GetLanguage()
+const std::string& System::GetPreferredLocales()
 {
     if (!this->systemInfo.language.empty())
         return this->systemInfo.language;
@@ -184,24 +184,24 @@ const std::string& System::GetSystemTheme()
 
 // clang-format off
 constexpr auto languages = BidirectionalMap<>::Create(
-    "Japanese",               SetLanguage_JA,
-    "US English",             SetLanguage_ENUS,
-    "French",                 SetLanguage_FR,
-    "German",                 SetLanguage_DE,
-    "Italian",                SetLanguage_IT,
-    "Spanish",                SetLanguage_ES,
-    "Chinese",                SetLanguage_ZHCN,
-    "Korean",                 SetLanguage_KO,
-    "Dutch",                  SetLanguage_NL,
-    "Portuguese",             SetLanguage_PT,
-    "Russian",                SetLanguage_RU,
-    "Taiwanese",              SetLanguage_ZHTW,
-    "British English",        SetLanguage_ENGB,
-    "Canadian French",        SetLanguage_FRCA,
-    "Latin American Spanish", SetLanguage_ES419,
-    "Chinese Simplified",     SetLanguage_ZHHANS,
-    "Chinese Traditional",    SetLanguage_ZHHANT,
-    "Brazilian Protuguese",   SetLanguage_PTBR
+    "jp",      SetLanguage_JA,
+    "en_US",   SetLanguage_ENUS,
+    "fr",      SetLanguage_FR,
+    "de",      SetLanguage_DE,
+    "it",      SetLanguage_IT,
+    "es",      SetLanguage_ES,
+    "zh_CN",   SetLanguage_ZHCN,
+    "ko",      SetLanguage_KO,
+    "nl",      SetLanguage_NL,
+    "pt",      SetLanguage_PT,
+    "ru",      SetLanguage_RU,
+    "zh_TW",   SetLanguage_ZHTW,
+    "en_GB",   SetLanguage_ENGB,
+    "fr_CA",   SetLanguage_FRCA,
+    "es_419",  SetLanguage_ES419,
+    "zh_HANS", SetLanguage_ZHHANS,
+    "zh_HANT", SetLanguage_ZHHANT,
+    "pt_BR",   SetLanguage_PTBR
 );
 
 constexpr auto models = BidirectionalMap<>::Create(

--- a/source/modules/system/wrap_system.cpp
+++ b/source/modules/system/wrap_system.cpp
@@ -58,11 +58,13 @@ int Wrap_System::GetNetworkInfo(lua_State* L)
     return 2;
 }
 
-int Wrap_System::GetLanguage(lua_State* L)
+int Wrap_System::GetPreferredLocales(lua_State* L)
 {
-    std::string language = instance()->GetLanguage();
+    std::string language = instance()->GetPreferredLocales();
 
+    lua_createtable(L, 1, 0);
     Luax::PushString(L, language);
+    lua_rawseti(L, -2, 1);
 
     return 1;
 }
@@ -146,22 +148,22 @@ int Wrap_System::GetPlayCoins(lua_State* L)
 // clang-format off
 static constexpr luaL_Reg functions[] =
 {
-    { "getColorTheme",     Wrap_System::GetSystemTheme    },
-    { "getFriendCode",     Wrap_System::GetFriendCode     },
-    { "getLanguage",       Wrap_System::GetLanguage       },
-    { "getModel",          Wrap_System::GetModel          },
-    { "getNetworkInfo",    Wrap_System::GetNetworkInfo    },
-    { "getOS",             Wrap_System::GetOS             },
-    { "getPowerInfo",      Wrap_System::GetPowerInfo      },
-    { "getProcessorCount", Wrap_System::GetProcessorCount },
-    { "getRegion",         Wrap_System::GetRegion         },
-    { "getUsername",       Wrap_System::GetUsername       },
-    { "getVersion",        Wrap_System::GetVersion        },
+    { "getColorTheme",       Wrap_System::GetSystemTheme      },
+    { "getFriendCode",       Wrap_System::GetFriendCode       },
+    { "getPreferredLocales", Wrap_System::GetPreferredLocales },
+    { "getModel",            Wrap_System::GetModel            },
+    { "getNetworkInfo",      Wrap_System::GetNetworkInfo      },
+    { "getOS",               Wrap_System::GetOS               },
+    { "getPowerInfo",        Wrap_System::GetPowerInfo        },
+    { "getProcessorCount",   Wrap_System::GetProcessorCount   },
+    { "getRegion",           Wrap_System::GetRegion           },
+    { "getUsername",         Wrap_System::GetUsername         },
+    { "getVersion",          Wrap_System::GetVersion          },
 #if defined(__3DS__)
-    { "getPlayCoins",      Wrap_System::GetPlayCoins      },
-    { "setPlayCoins",      Wrap_System::SetPlayCoins      },
+    { "getPlayCoins",        Wrap_System::GetPlayCoins        },
+    { "setPlayCoins",        Wrap_System::SetPlayCoins        },
 #endif
-    { 0,                   0                              }
+    { 0,                     0                                }
 };
 // clang-format on
 


### PR DESCRIPTION
## Summary of the Pull Request
Changes `love.system.getLanguage()` to `love.system.getPreferredLocales()` to be compatible with LÖVE 12.0's API.

## Validation Steps
Created the following `main.lua` and ran on 3DS and Switch

```lua
function love.draw()
    local locales = table.concat(love.system.getPreferredLocales(), ", ")
    love.graphics.print(locales)
end

function love.gamepadpressed(joy, button)
    if button == "start" then
        love.event.quit()
    end
end
```

## Checklist
- [x] Closes #NA
- [x] Successfully builds

## Screenshots
![2011-01-01_23-55-25 428_top](https://user-images.githubusercontent.com/6239208/159131454-0e2a3307-8dbc-48d6-a5b0-bc700147227f.png)
![2022031913151400-DB4ACF91897DEE47A4F659070EBDEC8B](https://user-images.githubusercontent.com/6239208/159131455-6933684f-2912-4f6e-ab9e-d53c098fc3e8.jpg)

## Additional Details
I'll probably have another pair of eyes look at the actual ISO-639 codes. Aside from that, it works. This will also break other people's games if they used `love.system.getLanguage()`. Not sure of the impact, but hopefully it is minimal.