### PR TITLE
Refactor Screen Rendering

### DIFF
--- a/include/common/bidirectionalmap.h
+++ b/include/common/bidirectionalmap.h
@@ -112,6 +112,21 @@ class BidirectionalMap
         return false;
     }
 
+    /* Can only be used on String-mapped Keys */
+    constexpr std::vector<const char*> GetNames() const
+    {
+        std::vector<const char*> strings;
+        strings.reserve(this->populated);
+
+        for (size_t i = 0; i < this->populated; i++)
+        {
+            if (this->entries[i].first != nullptr)
+                strings.emplace_back(this->entries[i].first);
+        }
+
+        return strings;
+    }
+
     constexpr std::pair<const Entry*, size_t> GetEntries() const
     {
         return { entries.data(), this->populated };
@@ -120,6 +135,7 @@ class BidirectionalMap
   private:
     std::array<Entry, Size> entries;
     const size_t populated;
+
     [[no_unique_address]] KeyComparator kc;
     [[no_unique_address]] ValueComparator vc;
 };

--- a/include/common/screenc.h
+++ b/include/common/screenc.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#if defined(__3DS__)
+    #include <3ds.h>
+
+    #include "citro2d/citro.h"
+#elif defined(__SWITCH__)
+    #include <switch.h>
+#endif
+
+#include <vector>
+
+typedef uint8_t RenderScreen;
+
+namespace love::common
+{
+    class Screen
+    {
+      protected:
+        template<typename T>
+        static bool FindSetCast(const auto& BiMap, const char* in, RenderScreen& value)
+        {
+            T temp;
+            bool success = BiMap.Find(in, temp);
+
+            value = static_cast<RenderScreen>(temp);
+            return success;
+        }
+
+        template<typename T>
+        static bool ReverseFindSetCast(const auto& BiMap, RenderScreen& in, const char*& value)
+        {
+            T temp;
+            bool success = BiMap.ReverseFind(in, temp);
+
+            value = static_cast<RenderScreen>(temp);
+            return success;
+        }
+
+        void SetActiveScreen(RenderScreen screen)
+        {
+            this->current = screen;
+        }
+
+        virtual int GetWidth(RenderScreen screen) = 0;
+
+        virtual int GetHeight(RenderScreen screen) = 0;
+
+      protected:
+        RenderScreen current;
+    };
+} // namespace love::common

--- a/include/common/screenc.h
+++ b/include/common/screenc.h
@@ -6,6 +6,8 @@
     #include "citro2d/citro.h"
 #elif defined(__SWITCH__)
     #include <switch.h>
+
+    #include "deko3d/deko.h"
 #endif
 
 #include <vector>
@@ -42,9 +44,9 @@ namespace love::common
             this->current = screen;
         }
 
-        virtual int GetWidth(RenderScreen screen) = 0;
+        virtual int GetWidth(RenderScreen screen = 0) = 0;
 
-        virtual int GetHeight(RenderScreen screen) = 0;
+        virtual int GetHeight() = 0;
 
       protected:
         RenderScreen current;

--- a/include/common/screenc.h
+++ b/include/common/screenc.h
@@ -2,12 +2,8 @@
 
 #if defined(__3DS__)
     #include <3ds.h>
-
-    #include "citro2d/citro.h"
 #elif defined(__SWITCH__)
     #include <switch.h>
-
-    #include "deko3d/deko.h"
 #endif
 
 #include <vector>
@@ -22,7 +18,7 @@ namespace love::common
         template<typename T>
         static bool FindSetCast(const auto& BiMap, const char* in, RenderScreen& value)
         {
-            T temp;
+            T temp       = static_cast<T>(0);
             bool success = BiMap.Find(in, temp);
 
             value = static_cast<RenderScreen>(temp);
@@ -32,10 +28,9 @@ namespace love::common
         template<typename T>
         static bool ReverseFindSetCast(const auto& BiMap, RenderScreen& in, const char*& value)
         {
-            T temp;
-            bool success = BiMap.ReverseFind(in, temp);
+            T temp       = static_cast<T>(0);
+            bool success = BiMap.ReverseFind(temp, value);
 
-            value = static_cast<RenderScreen>(temp);
             return success;
         }
 

--- a/include/modules/graphics/graphics.h
+++ b/include/modules/graphics/graphics.h
@@ -46,20 +46,14 @@
     #include "objects/shader/wrap_shader.h"
 #endif
 
+#include "common/screen.h"
+
 namespace love
 {
     class Graphics : public Module
     {
       public:
         static const size_t MAX_USER_STACK_DEPTH = 128;
-
-        enum class Screen : uint8_t;
-
-#if defined(__SWITCH__)
-        static constexpr int MAX_SCREENS = 1;
-#elif defined(__3DS__)
-        static constexpr int MAX_SCREENS = 3;
-#endif
 
         enum DrawMode
         {
@@ -218,15 +212,25 @@ namespace love
 
         void SetBackgroundColor(const Colorf& color);
 
-        virtual Screen GetActiveScreen() const = 0;
+        /* render screen */
 
-        virtual const int GetWidth(Screen screen) const = 0;
+        void SetActiveScreen(RenderScreen screen)
+        {
+            Graphics::ACTIVE_SCREEN = screen;
+        }
 
-        virtual const int GetHeight() const = 0;
+        const RenderScreen GetActiveScreen() const
+        {
+            return Graphics::ACTIVE_SCREEN;
+        };
 
-        virtual std::vector<const char*> GetScreens() const = 0;
+        const int GetWidth(RenderScreen screen) const;
 
-        virtual void SetActiveScreen(Screen screen) = 0;
+        const int GetHeight() const;
+
+        std::vector<const char*> GetScreens() const;
+
+        /* end screens */
 
         bool GetScissor(Rect& scissor) const;
 
@@ -355,7 +359,7 @@ namespace love
         virtual void Polygon(DrawMode mode, const Vector2* points, size_t count,
                              bool skipLastFilledVertex = true) = 0;
 #else
-        virtual void Polygon(DrawMode mode, const Vector2* points, size_t count) = 0;
+        virtual void Polygon(DrawMode mode, const Vector2* points, size_t count)             = 0;
 #endif
 
         virtual void Arc(DrawMode drawmode, ArcMode arcmode, float x, float y, float radius,
@@ -558,13 +562,9 @@ namespace love
 
         bool SetMode(int width, int height);
 
-        static constexpr float MIN_DEPTH  = 1.0f / 16384.0f;
-        static inline float CURRENT_DEPTH = 0;
-        static inline int ACTIVE_SCREEN   = 0;
-
-        static bool GetConstant(const char* in, Screen& out);
-        static bool GetConstant(Screen in, const char*& out);
-        static std::vector<const char*> GetConstants(Screen);
+        static constexpr float MIN_DEPTH         = 1.0f / 16384.0f;
+        static inline float CURRENT_DEPTH        = 0;
+        static inline RenderScreen ACTIVE_SCREEN = 0;
 
         static bool GetConstant(const char* in, DrawMode& out);
         static bool GetConstant(DrawMode in, const char*& out);

--- a/include/modules/graphics/graphics.h
+++ b/include/modules/graphics/graphics.h
@@ -7,6 +7,7 @@
 
 #include "common/colors.h"
 #include "common/module.h"
+#include "common/screen.h"
 #include "common/vector.h"
 
 /* OBJECTS */
@@ -45,8 +46,6 @@
 
     #include "objects/shader/wrap_shader.h"
 #endif
-
-#include "common/screen.h"
 
 namespace love
 {
@@ -120,6 +119,10 @@ namespace love
             STACK_TRANSFORM,
             STACK_MAX_ENUM
         };
+
+        static constexpr float MIN_DEPTH         = 1.0f / 16384.0f;
+        static inline float CURRENT_DEPTH        = 0;
+        static inline RenderScreen ACTIVE_SCREEN = 0;
 
         struct ColorMask
         {
@@ -214,15 +217,9 @@ namespace love
 
         /* render screen */
 
-        void SetActiveScreen(RenderScreen screen)
-        {
-            Graphics::ACTIVE_SCREEN = screen;
-        }
+        void SetActiveScreen(RenderScreen screen);
 
-        const RenderScreen GetActiveScreen() const
-        {
-            return Graphics::ACTIVE_SCREEN;
-        };
+        const RenderScreen GetActiveScreen() const;
 
         const int GetWidth(RenderScreen screen) const;
 
@@ -561,10 +558,6 @@ namespace love
         virtual void Present() = 0;
 
         bool SetMode(int width, int height);
-
-        static constexpr float MIN_DEPTH         = 1.0f / 16384.0f;
-        static inline float CURRENT_DEPTH        = 0;
-        static inline RenderScreen ACTIVE_SCREEN = 0;
 
         static bool GetConstant(const char* in, DrawMode& out);
         static bool GetConstant(DrawMode in, const char*& out);

--- a/include/modules/graphics/wrap_graphics.h
+++ b/include/modules/graphics/wrap_graphics.h
@@ -161,6 +161,10 @@ namespace Wrap_Graphics
 
     int Set3D(lua_State* L);
 
+    int GetWide(lua_State* L);
+
+    int SetWide(lua_State* L);
+
     /* End Nintendo 3DS */
 
     int Register(lua_State* L);

--- a/platform/3ds/include/citro2d/citro.h
+++ b/platform/3ds/include/citro2d/citro.h
@@ -24,6 +24,10 @@ class citro2d
 
     ~citro2d();
 
+    void DestroyFramebuffers();
+
+    void CreateFramebuffers();
+
     void BindFramebuffer(love::Canvas* canvas = nullptr);
 
     void ClearColor(const Colorf& color);
@@ -43,9 +47,39 @@ class citro2d
 
     void SetTextureWrap(love::Texture* texture, const love::Texture::Wrap& filter);
 
-    void Set3D(bool enable);
+    template<typename T>
+    int ModeChange(const T& func)
+    {
+        this->DestroyFramebuffers();
+        func();
+        this->CreateFramebuffers();
+    }
 
-    bool Get3D() const;
+    void SetWideMode(bool enable)
+    {
+        if (this->GetWide())
+            return;
+
+        this->ModeChange([enable]() { gfxSetWide(enable); });
+    }
+
+    void Set3D(bool enable)
+    {
+        if (this->Get3D())
+            return;
+
+        this->ModeChange([enable]() { gfxSet3D(enable); });
+    }
+
+    const bool Get3D() const
+    {
+        return gfxIs3D();
+    }
+
+    const bool GetWide() const
+    {
+        return gfxIsWide();
+    }
 
     void DeferCallToEndOfFrame(std::function<void()>&& func)
     {

--- a/platform/3ds/include/citro2d/citro.h
+++ b/platform/3ds/include/citro2d/citro.h
@@ -48,7 +48,7 @@ class citro2d
     void SetTextureWrap(love::Texture* texture, const love::Texture::Wrap& filter);
 
     template<typename T>
-    int ModeChange(const T& func)
+    void ModeChange(const T& func)
     {
         this->DestroyFramebuffers();
         func();
@@ -57,17 +57,11 @@ class citro2d
 
     void SetWideMode(bool enable)
     {
-        if (this->GetWide())
-            return;
-
         this->ModeChange([enable]() { gfxSetWide(enable); });
     }
 
     void Set3D(bool enable)
     {
-        if (this->Get3D())
-            return;
-
         this->ModeChange([enable]() { gfxSet3D(enable); });
     }
 

--- a/platform/3ds/include/citro2d/graphics.h
+++ b/platform/3ds/include/citro2d/graphics.h
@@ -10,34 +10,12 @@
 #define RENDERER_VENDOR  "devkitPro"
 #define RENDERER_DEVICE  "DMP PICA200"
 
-#define SCREEN_TOP_WIDTH 400
-#define SCREEN_BOT_WIDTH 320
-#define SCREEN_HEIGHT    240
-
-enum class love::Graphics::Screen : uint8_t
-{
-    SCREEN_LEFT,
-    SCREEN_RIGHT,
-    SCREEN_BOTTOM,
-    SCREEN_MAX_ENUM
-};
-
 namespace love::citro2d
 {
     class Graphics : public love::Graphics
     {
       public:
         Graphics();
-
-        Screen GetActiveScreen() const override;
-
-        std::vector<const char*> GetScreens() const override;
-
-        const int GetWidth(Screen screen) const override;
-
-        const int GetHeight() const override;
-
-        void SetActiveScreen(Screen screen) override;
 
         RendererInfo GetRendererInfo() const override;
 
@@ -115,18 +93,15 @@ namespace love::citro2d
 
         void Set3D(bool enable);
 
-        bool Get3D() const;
+        const bool Get3D() const;
 
+        void SetWide(bool enable);
+
+        const bool GetWide() const;
         /* End Nintendo 3DS */
 
         /* Useless */
 
         void SetColorMask(ColorMask mask) override;
-
-        static constexpr int MAX_2D_SCREENS = 2;
-
-        static bool GetConstant(const char* in, Screen& out);
-        static bool GetConstant(Screen in, const char*& out);
-        static std::vector<const char*> GetConstants(Screen);
     };
 } // namespace love::citro2d

--- a/platform/3ds/include/common/screen.h
+++ b/platform/3ds/include/common/screen.h
@@ -17,6 +17,9 @@ namespace love
         static constexpr int BOTTOM_WIDTH = 0x140;
         static constexpr int HEIGHT       = 0x0F0;
 
+        /*
+        ** 3D screens when 3D is enabled
+        */
         enum class CtrScreen : RenderScreen
         {
             CTR_SCREEN_LEFT,
@@ -25,16 +28,20 @@ namespace love
             CTR_SCREEN_MAX_ENUM
         };
 
+        /*
+        ** 2D screens when 3D is disabled
+        ** BOTTOM is 0x02 to properly index it in the citro2d class
+        */
         enum class Ctr2dScreen : RenderScreen
         {
             CTR_2D_SCREEN_TOP,
-            CTR_2D_SCREEN_BOTTOM,
+            CTR_2D_SCREEN_BOTTOM = 0x02,
             CTR_2D_SCREEN_MAX_ENUM
         };
 
-        int GetWidth(RenderScreen screen) override;
+        int GetWidth(RenderScreen screen = 0) override;
 
-        int GetHeight(RenderScreen screen) override;
+        int GetHeight() override;
 
         static bool GetConstant(const char* in, RenderScreen& out);
         static bool GetConstant(RenderScreen in, const char*& out);

--- a/platform/3ds/include/common/screen.h
+++ b/platform/3ds/include/common/screen.h
@@ -17,6 +17,8 @@ namespace love
         static constexpr int BOTTOM_WIDTH = 0x140;
         static constexpr int HEIGHT       = 0x0F0;
 
+        static constexpr int TOP_WIDE_WIDTH = 0x320;
+
         /*
         ** 3D screens when 3D is enabled
         */
@@ -46,5 +48,5 @@ namespace love
         static bool GetConstant(const char* in, RenderScreen& out);
         static bool GetConstant(RenderScreen in, const char*& out);
         static std::vector<const char*> GetConstants(RenderScreen);
-    }
+    };
 } // namespace love

--- a/platform/3ds/include/common/screen.h
+++ b/platform/3ds/include/common/screen.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "common/screenc.h"
+
+namespace love
+{
+    class Screen : common::Screen
+    {
+      public:
+        static Screen& Instance()
+        {
+            static Screen screen;
+            return screen;
+        };
+
+        static constexpr int TOP_WIDTH    = 0x190;
+        static constexpr int BOTTOM_WIDTH = 0x140;
+        static constexpr int HEIGHT       = 0x0F0;
+
+        enum class CtrScreen : RenderScreen
+        {
+            CTR_SCREEN_LEFT,
+            CTR_SCREEN_RIGHT,
+            CTR_SCREEN_BOTTOM,
+            CTR_SCREEN_MAX_ENUM
+        };
+
+        enum class Ctr2dScreen : RenderScreen
+        {
+            CTR_2D_SCREEN_TOP,
+            CTR_2D_SCREEN_BOTTOM,
+            CTR_2D_SCREEN_MAX_ENUM
+        };
+
+        int GetWidth(RenderScreen screen) override;
+
+        int GetHeight(RenderScreen screen) override;
+
+        static bool GetConstant(const char* in, RenderScreen& out);
+        static bool GetConstant(RenderScreen in, const char*& out);
+        static std::vector<const char*> GetConstants(RenderScreen);
+    }
+} // namespace love

--- a/platform/3ds/source/citro2d/citro.cpp
+++ b/platform/3ds/source/citro2d/citro.cpp
@@ -26,8 +26,6 @@ citro2d::citro2d()
 
     C2D_SetTintMode(C2D_TintMult);
 
-    this->targets.reserve(4);
-
     love::Texture::Filter filter;
     filter.min = filter.mag = love::Texture::FILTER_NEAREST;
     this->SetTextureFilter(filter);
@@ -36,6 +34,7 @@ citro2d::citro2d()
     wrap.s = wrap.t = wrap.r = love::Texture::WRAP_CLAMP;
     this->SetTextureWrap(wrap);
 
+    this->targets.reserve(4);
     this->CreateFramebuffers();
 }
 

--- a/platform/3ds/source/citro2d/citro.cpp
+++ b/platform/3ds/source/citro2d/citro.cpp
@@ -28,10 +28,6 @@ citro2d::citro2d()
 
     this->targets.reserve(4);
 
-    this->targets = { C2D_CreateScreenTarget(GFX_TOP, GFX_LEFT),
-                      C2D_CreateScreenTarget(GFX_TOP, GFX_RIGHT),
-                      C2D_CreateScreenTarget(GFX_BOTTOM, GFX_LEFT) };
-
     love::Texture::Filter filter;
     filter.min = filter.mag = love::Texture::FILTER_NEAREST;
     this->SetTextureFilter(filter);
@@ -39,6 +35,21 @@ citro2d::citro2d()
     love::Texture::Wrap wrap;
     wrap.s = wrap.t = wrap.r = love::Texture::WRAP_CLAMP;
     this->SetTextureWrap(wrap);
+
+    this->CreateFramebuffers();
+}
+
+void citro2d::DestroyFramebuffers()
+{
+    for (auto framebuffer : this->targets)
+        C3D_RenderTargetDelete(framebuffer);
+}
+
+void citro2d::CreateFramebuffers()
+{
+    this->targets = { C2D_CreateScreenTarget(GFX_TOP, GFX_LEFT),
+                      C2D_CreateScreenTarget(GFX_TOP, GFX_RIGHT),
+                      C2D_CreateScreenTarget(GFX_BOTTOM, GFX_LEFT) };
 }
 
 citro2d::~citro2d()
@@ -70,16 +81,6 @@ void citro2d::SetColorMask(const love::Graphics::ColorMask& mask)
     writeMask |= mask.GetColorMask();
 
     C3D_DepthTest(true, GPU_GEQUAL, static_cast<GPU_WRITEMASK>(writeMask));
-}
-
-void citro2d::Set3D(bool enable)
-{
-    gfxSet3D(enable);
-}
-
-bool citro2d::Get3D() const
-{
-    return gfxIs3D();
 }
 
 void citro2d::EnsureInFrame()

--- a/platform/3ds/source/citro2d/graphics.cpp
+++ b/platform/3ds/source/citro2d/graphics.cpp
@@ -4,7 +4,6 @@
 #include "common/bidirectionalmap.h"
 
 using namespace love;
-using Screen = love::Graphics::Screen;
 
 #define TRANSPARENCY       C2D_Color32(0, 0, 0, 1)
 #define TRANSPARENCY_DEBUG C2D_Color32(255, 0, 0, 96)
@@ -12,26 +11,6 @@ using Screen = love::Graphics::Screen;
 love::citro2d::Graphics::Graphics()
 {
     this->RestoreState(this->states.back());
-}
-
-void love::citro2d::Graphics::SetActiveScreen(Screen screen)
-{
-    switch (screen)
-    {
-        case Screen::SCREEN_LEFT:
-            Graphics::ACTIVE_SCREEN = 0;
-            return;
-        case Screen::SCREEN_RIGHT:
-            Graphics::ACTIVE_SCREEN = 1;
-            return;
-        case Screen::SCREEN_BOTTOM:
-            Graphics::ACTIVE_SCREEN = 2;
-            return;
-        case Screen::SCREEN_MAX_ENUM:
-        default: //< if it defaults from something like "top"
-            throw love::Exception("Invalid screen type!"); //< shouldn't happen
-            break;
-    }
 }
 
 void love::citro2d::Graphics::SetBlendMode(BlendMode mode, BlendAlpha alphaMode)
@@ -116,56 +95,24 @@ void love::citro2d::Graphics::SetBlendMode(BlendMode mode, BlendAlpha alphaMode)
     this->states.back().blendAlphaMode = alphaMode;
 }
 
-const int love::citro2d::Graphics::GetWidth(Screen screen) const
-{
-    switch (screen)
-    {
-        case Screen::SCREEN_LEFT:
-        case Screen::SCREEN_RIGHT:
-        default:
-            return SCREEN_TOP_WIDTH;
-        case Screen::SCREEN_BOTTOM:
-            return SCREEN_BOT_WIDTH;
-    }
-}
-
 void love::citro2d::Graphics::Set3D(bool enabled)
 {
     ::citro2d::Instance().Set3D(enabled);
 }
 
-bool love::citro2d::Graphics::Get3D() const
+const bool love::citro2d::Graphics::Get3D() const
 {
     return ::citro2d::Instance().Get3D();
 }
 
-const int love::citro2d::Graphics::GetHeight() const
+void love::citro2d::Graphics::SetWide(bool enabled)
 {
-    return SCREEN_HEIGHT;
+    ::citro2d::Instance().SetWideMode(enabled);
 }
 
-Graphics::Screen love::citro2d::Graphics::GetActiveScreen() const
+const bool love::citro2d::Graphics::GetWide() const
 {
-    switch (Graphics::ACTIVE_SCREEN)
-    {
-        case 0:
-            return Screen::SCREEN_LEFT;
-        case 1:
-            return Screen::SCREEN_RIGHT;
-        case 2:
-            return Screen::SCREEN_BOTTOM;
-        default:
-            return Screen::SCREEN_LEFT;
-    }
-}
-
-std::vector<const char*> love::citro2d::Graphics::GetScreens() const
-{
-    auto constants = (this->Get3D())
-                         ? love::Graphics::GetConstants(Screen::SCREEN_MAX_ENUM)
-                         : love::citro2d::Graphics::GetConstants(Screen::SCREEN_MAX_ENUM);
-
-    return constants;
+    return ::citro2d::Instance().GetWide();
 }
 
 void love::citro2d::Graphics::Clear(std::optional<Colorf> color, std::optional<int> stencil,
@@ -655,35 +602,6 @@ Graphics::RendererInfo love::citro2d::Graphics::GetRendererInfo() const
     info.version = RENDERER_VERSION;
 
     return info;
-}
-
-// clang-format off
-constexpr auto plainScreens = BidirectionalMap<>::Create(
-    "top",    Graphics::Screen::SCREEN_LEFT,
-    "bottom", Graphics::Screen::SCREEN_BOTTOM
-);
-// clang-format on
-
-bool love::citro2d::Graphics::GetConstant(const char* in, Screen& out)
-{
-    return plainScreens.Find(in, out);
-}
-
-bool love::citro2d::Graphics::GetConstant(Screen in, const char*& out)
-{
-    return plainScreens.ReverseFind(in, out);
-}
-
-std::vector<const char*> love::citro2d::Graphics::GetConstants(Screen)
-{
-    auto entries = plainScreens.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
 }
 
 /* 2D Screens */

--- a/platform/3ds/source/common/screen.cpp
+++ b/platform/3ds/source/common/screen.cpp
@@ -1,6 +1,8 @@
 #include "common/screen.h"
 
+#include "citro2d/citro.h"
 #include "common/bidirectionalmap.h"
+#include "modules/graphics/graphics.h"
 
 using namespace love;
 
@@ -24,6 +26,8 @@ int Screen::GetWidth(RenderScreen screen)
         {
             case (int)Screen::Ctr2dScreen::CTR_2D_SCREEN_TOP:
             default:
+                if (::citro2d::Instance().GetWide())
+                    return Screen::TOP_WIDE_WIDTH;
                 return Screen::TOP_WIDTH;
             case (int)Screen::Ctr2dScreen::CTR_2D_SCREEN_BOTTOM:
                 return Screen::BOTTOM_WIDTH;
@@ -31,7 +35,7 @@ int Screen::GetWidth(RenderScreen screen)
     }
 }
 
-int Screen::GetHeight(RenderScreen screen)
+int Screen::GetHeight()
 {
     return Screen::HEIGHT;
 }

--- a/platform/3ds/source/common/screen.cpp
+++ b/platform/3ds/source/common/screen.cpp
@@ -1,0 +1,74 @@
+#include "common/screen.h"
+
+#include "common/bidirectionalmap.h"
+
+using namespace love;
+
+int Screen::GetWidth(RenderScreen screen)
+{
+    if (::citro2d::Instance().Get3D())
+    {
+        switch (screen)
+        {
+            case (int)Screen::CtrScreen::CTR_SCREEN_LEFT:
+            case (int)Screen::CtrScreen::CTR_SCREEN_RIGHT:
+            default:
+                return Screen::TOP_WIDTH;
+            case (int)Screen::CtrScreen::CTR_SCREEN_BOTTOM:
+                return Screen::BOTTOM_WIDTH;
+        }
+    }
+    else
+    {
+        switch (screen)
+        {
+            case (int)Screen::Ctr2dScreen::CTR_2D_SCREEN_TOP:
+            default:
+                return Screen::TOP_WIDTH;
+            case (int)Screen::Ctr2dScreen::CTR_2D_SCREEN_BOTTOM:
+                return Screen::BOTTOM_WIDTH;
+        }
+    }
+}
+
+int Screen::GetHeight(RenderScreen screen)
+{
+    return Screen::HEIGHT;
+}
+
+// clang-format off
+constexpr auto ScreenTypes = BidirectionalMap<>::Create(
+    "left",   Screen::CtrScreen::CTR_SCREEN_LEFT,
+    "right",  Screen::CtrScreen::CTR_SCREEN_RIGHT,
+    "bottom", Screen::CtrScreen::CTR_SCREEN_BOTTOM
+);
+
+constexpr auto ScreenTypes2d = BidirectionalMap<>::Create(
+    "top",    Screen::Ctr2dScreen::CTR_2D_SCREEN_TOP,
+    "bottom", Screen::Ctr2dScreen::CTR_2D_SCREEN_BOTTOM
+);
+// clang-format on
+
+bool Screen::GetConstant(const char* in, RenderScreen& out)
+{
+    if (::citro2d::Instance().Get3D())
+        return Screen::FindSetCast<CtrScreen>(ScreenTypes, in, out);
+
+    return Screen::FindSetCast<Ctr2dScreen>(ScreenTypes2d, in, out);
+}
+
+bool Screen::GetConstant(RenderScreen in, const char*& out)
+{
+    if (::citro2d::Instance().Get3D())
+        return Screen::ReverseFindSetCast<CtrScreen>(ScreenTypes, in, out);
+
+    return Screen::ReverseFindSetCast<Ctr2dScreen>(ScreenTypes2d, in, out);
+}
+
+std::vector<const char*> Screen::GetConstants(RenderScreen)
+{
+    if (::citro2d::Instance().Get3D())
+        return ScreenTypes.GetNames();
+
+    return ScreenTypes2d.GetNames();
+}

--- a/platform/3ds/source/modules/keyboard.cpp
+++ b/platform/3ds/source/modules/keyboard.cpp
@@ -50,12 +50,5 @@ bool Keyboard::GetConstant(KeyboardType in, const char*& out)
 
 std::vector<const char*> Keyboard::GetConstants(KeyboardType)
 {
-    auto entries = keyboardTypes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return keyboardTypes.GetNames();
 }

--- a/platform/3ds/source/modules/system.cpp
+++ b/platform/3ds/source/modules/system.cpp
@@ -282,14 +282,7 @@ bool System::GetConstant(CFG_Language in, const char*& out)
 
 std::vector<const char*> System::GetConstants(CFG_Language)
 {
-    auto entries = languages.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return languages.GetNames();
 }
 
 /* MODEL CONSTANTS */
@@ -306,14 +299,7 @@ bool System::GetConstant(CFG_SystemModel in, const char*& out)
 
 std::vector<const char*> System::GetConstants(CFG_SystemModel)
 {
-    auto entries = models.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return models.GetNames();
 }
 
 /* REGION CONSTANTS */
@@ -330,12 +316,5 @@ bool System::GetConstant(CFG_Region in, const char*& out)
 
 std::vector<const char*> System::GetConstants(CFG_Region)
 {
-    auto entries = regions.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return regions.GetNames();
 }

--- a/platform/switch/include/common/screen.h
+++ b/platform/switch/include/common/screen.h
@@ -13,8 +13,11 @@ namespace love
             return screen;
         };
 
-        static constexpr int WIDTH  = 0x500;
-        static constexpr int HEIGHT = 0x2D0;
+        static constexpr int HANDHELD_WIDTH  = 0x500;
+        static constexpr int HANDHELD_HEIGHT = 0x2D0;
+
+        static constexpr int DOCKED_WIDTH  = 0x780;
+        static constexpr int DOCKED_HEIGHT = 0x438;
 
         enum class HacScreen : RenderScreen
         {
@@ -22,9 +25,9 @@ namespace love
             HAC_SCREEN_MAX_ENUM
         };
 
-        int GetWidth(RenderScreen screen) override;
+        int GetWidth(RenderScreen screen = 0) override;
 
-        int GetHeight(RenderScreen screen) override;
+        int GetHeight(RenderScreen screen = 0) override;
 
         static bool GetConstant(const char* in, RenderScreen& out);
         static bool GetConstant(RenderScreen in, const char*& out);

--- a/platform/switch/include/common/screen.h
+++ b/platform/switch/include/common/screen.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "common/screenc.h"
+
+namespace love
+{
+    class Screen : common::Screen
+    {
+      public:
+        static Screen& Instance()
+        {
+            static Screen screen;
+            return screen;
+        };
+
+        static constexpr int WIDTH  = 0x500;
+        static constexpr int HEIGHT = 0x2D0;
+
+        enum class HacScreen : RenderScreen
+        {
+            HAC_SCREEN_DEFAULT,
+            HAC_SCREEN_MAX_ENUM
+        };
+
+        int GetWidth(RenderScreen screen) override;
+
+        int GetHeight(RenderScreen screen) override;
+
+        static bool GetConstant(const char* in, RenderScreen& out);
+        static bool GetConstant(RenderScreen in, const char*& out);
+        static std::vector<const char*> GetConstants(RenderScreen);
+    }
+} // namespace love

--- a/platform/switch/include/common/screen.h
+++ b/platform/switch/include/common/screen.h
@@ -27,10 +27,10 @@ namespace love
 
         int GetWidth(RenderScreen screen = 0) override;
 
-        int GetHeight(RenderScreen screen = 0) override;
+        int GetHeight() override;
 
         static bool GetConstant(const char* in, RenderScreen& out);
         static bool GetConstant(RenderScreen in, const char*& out);
         static std::vector<const char*> GetConstants(RenderScreen);
-    }
+    };
 } // namespace love

--- a/platform/switch/include/deko3d/deko.h
+++ b/platform/switch/include/deko3d/deko.h
@@ -107,7 +107,14 @@ class deko3d
 
     void SetStencil(DkStencilOp op, DkCompareOp compare, int value);
 
-    std::pair<uint32_t, uint32_t> OnOperationMode(AppletOperationMode mode);
+    void OnOperationMode(std::pair<uint32_t, uint32_t>& size);
+
+    bool IsHandheldMode()
+    {
+        AppletOperationMode mode = appletGetOperationMode();
+
+        return mode == AppletOperationMode::AppletOperationMode_Handheld;
+    }
 
     dk::Device GetDevice()
     {

--- a/platform/switch/include/deko3d/graphics.h
+++ b/platform/switch/include/deko3d/graphics.h
@@ -9,12 +9,6 @@
 #define RENDERER_VENDOR  "devkitPro"
 #define RENDERER_DEVICE  "NVIDIA Tegra X1"
 
-enum class love::Graphics::Screen : uint8_t
-{
-    SCREEN_DEFAULT,
-    SCREEN_MAX_ENUM
-};
-
 namespace love::deko3d
 {
     class Graphics : public love::Graphics
@@ -23,16 +17,6 @@ namespace love::deko3d
         Graphics();
 
         virtual ~Graphics();
-
-        Screen GetActiveScreen() const override;
-
-        std::vector<const char*> GetScreens() const override;
-
-        const int GetWidth(Screen screen) const override;
-
-        const int GetHeight() const override;
-
-        void SetActiveScreen(Screen screen) override;
 
         void Clear(std::optional<Colorf> color, std::optional<int> stencil,
                    std::optional<double> depth) override;

--- a/platform/switch/source/common/screen.cpp
+++ b/platform/switch/source/common/screen.cpp
@@ -14,7 +14,7 @@ int Screen::GetWidth(RenderScreen)
     return Screen::DOCKED_WIDTH;
 }
 
-int Screen::GetHeight(RenderScreen)
+int Screen::GetHeight()
 {
     if (::deko3d::Instance().IsHandheldMode())
         return Screen::HANDHELD_HEIGHT;

--- a/platform/switch/source/common/screen.cpp
+++ b/platform/switch/source/common/screen.cpp
@@ -1,6 +1,8 @@
 #include "common/screen.h"
 
 #include "common/bidirectionalmap.h"
+#include "deko3d/deko.h"
+#include "modules/graphics/graphics.h"
 
 using namespace love;
 

--- a/platform/switch/source/common/screen.cpp
+++ b/platform/switch/source/common/screen.cpp
@@ -6,12 +6,18 @@ using namespace love;
 
 int Screen::GetWidth(RenderScreen)
 {
-    return Screen::WIDTH;
+    if (::deko3d::Instance().IsHandheldMode())
+        return Screen::HANDHELD_WIDTH;
+
+    return Screen::DOCKED_WIDTH;
 }
 
 int Screen::GetHeight(RenderScreen)
 {
-    return Screen::HEIGHT;
+    if (::deko3d::Instance().IsHandheldMode())
+        return Screen::HANDHELD_HEIGHT;
+
+    return Screen::DOCKED_HEIGHT;
 }
 
 // clang-format off

--- a/platform/switch/source/common/screen.cpp
+++ b/platform/switch/source/common/screen.cpp
@@ -1,0 +1,36 @@
+#include "common/screen.h"
+
+#include "common/bidirectionalmap.h"
+
+using namespace love;
+
+int Screen::GetWidth(RenderScreen)
+{
+    return Screen::WIDTH;
+}
+
+int Screen::GetHeight(RenderScreen)
+{
+    return Screen::HEIGHT;
+}
+
+// clang-format off
+constexpr auto ScreenTypes = BidirectionalMap<>::Create(
+    "default", Screen::HacScreen::HAC_SCREEN_DEFAULT
+);
+// clang-format on
+
+bool Screen::GetConstant(const char* in, RenderScreen& out)
+{
+    return Screen::FindSetCast<HacScreen>(ScreenTypes, in, out);
+}
+
+bool Screen::GetConstant(RenderScreen in, const char*& out)
+{
+    return Screen::ReverseFindSetCast<HacScreen>(ScreenTypes, in, out);
+}
+
+std::vector<const char*> Screen::GetConstants(RenderScreen)
+{
+    return ScreenTypes.GetNames();
+}

--- a/platform/switch/source/deko3d/graphics.cpp
+++ b/platform/switch/source/deko3d/graphics.cpp
@@ -4,7 +4,6 @@
 #include "polyline/common.h"
 
 using namespace love;
-using Screen = love::Graphics::Screen;
 
 love::deko3d::Graphics::Graphics()
 {
@@ -36,39 +35,6 @@ love::deko3d::Graphics::Graphics()
 
 love::deko3d::Graphics::~Graphics()
 {}
-
-const int love::deko3d::Graphics::GetWidth(Screen screen) const
-{
-    switch (screen)
-    {
-        case Screen::SCREEN_DEFAULT:
-        default:
-            return this->width;
-    }
-
-    return 0;
-}
-
-const int love::deko3d::Graphics::GetHeight() const
-{
-    return this->height;
-}
-
-void love::deko3d::Graphics::SetActiveScreen(Screen screen)
-{
-    if (screen == Screen::SCREEN_MAX_ENUM)
-        throw love::Exception("invalid screen, expected 'default'.");
-}
-
-Graphics::Screen love::deko3d::Graphics::GetActiveScreen() const
-{
-    return Screen::SCREEN_DEFAULT;
-}
-
-std::vector<const char*> love::deko3d::Graphics::GetScreens() const
-{
-    return Graphics::GetConstants(Screen::SCREEN_MAX_ENUM);
-}
 
 void Graphics::SetCanvas(Canvas* canvas)
 {

--- a/platform/switch/source/driver/hidrv.cpp
+++ b/platform/switch/source/driver/hidrv.cpp
@@ -56,7 +56,9 @@ void Hidrv::CheckFocus()
             }
             case AppletMessage_OperationModeChanged:
             {
-                auto size = ::deko3d::Instance().OnOperationMode(appletGetOperationMode());
+                std::pair<uint32_t, uint32_t> size;
+                ::deko3d::Instance().OnOperationMode(size);
+
                 this->SendResize(size.first, size.second);
 
                 break;

--- a/platform/switch/source/modules/keyboard.cpp
+++ b/platform/switch/source/modules/keyboard.cpp
@@ -72,12 +72,5 @@ bool Keyboard::GetConstant(KeyboardType in, const char*& out)
 
 std::vector<const char*> Keyboard::GetConstants(KeyboardType)
 {
-    auto entries = keyboardTypes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return keyboardTypes.GetNames();
 }

--- a/platform/switch/source/modules/system.cpp
+++ b/platform/switch/source/modules/system.cpp
@@ -254,14 +254,7 @@ bool System::GetConstant(SetLanguage in, const char*& out)
 
 std::vector<const char*> System::GetConstants(SetLanguage)
 {
-    auto entries = languages.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return languages.GetNames();
 }
 
 /* MODEL CONSTANTS */
@@ -278,14 +271,7 @@ bool System::GetConstant(SetSysProductModel in, const char*& out)
 
 std::vector<const char*> System::GetConstants(SetSysProductModel)
 {
-    auto entries = models.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return models.GetNames();
 }
 
 /* REGION CONSTANTS */
@@ -302,12 +288,5 @@ bool System::GetConstant(SetRegion in, const char*& out)
 
 std::vector<const char*> System::GetConstants(SetRegion)
 {
-    auto entries = regions.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return regions.GetNames();
 }

--- a/platform/switch/source/modules/window.cpp
+++ b/platform/switch/source/modules/window.cpp
@@ -5,14 +5,18 @@ using namespace love;
 #include "common/exception.h"
 #include "deko3d/deko.h"
 
+#include "common/screen.h"
+
 Window::Window()
 {
-    this->fullscreenModes = { { 1280, 720 }, { 1920, 1080 } };
+    this->fullscreenModes = { { Screen::HANDHELD_WIDTH, Screen::HANDHELD_HEIGHT },
+                              { Screen::DOCKED_WIDTH, Screen::DOCKED_HEIGHT } };
 }
 
 void Window::GetWindow(int& width, int& height)
 {
-    auto size = ::deko3d::Instance().OnOperationMode(appletGetOperationMode());
+    std::pair<uint32_t, uint32_t> size;
+    ::deko3d::Instance().OnOperationMode(size);
 
     width  = size.first;
     height = size.second;
@@ -22,7 +26,9 @@ void Window::GetWindow(int& width, int& height)
 
 bool Window::CreateWindowAndContext()
 {
-    auto size = ::deko3d::Instance().OnOperationMode(appletGetOperationMode());
+    std::pair<uint32_t, uint32_t> size;
+    ::deko3d::Instance().OnOperationMode(size);
+
     this->OnSizeChanged(size.first, size.second);
 
     return true;

--- a/platform/switch/source/objects/truetyperasterizer.cpp
+++ b/platform/switch/source/objects/truetyperasterizer.cpp
@@ -18,7 +18,7 @@ TrueTypeRasterizer::TrueTypeRasterizer(FT_Library library, love::Data* data, int
 
     FT_Error err = FT_Err_Ok;
     err          = FT_New_Memory_Face(library, (const FT_Byte*)data->GetData(), data->GetSize(), 0,
-                             &this->face);
+                                      &this->face);
 
     if (err != FT_Err_Ok)
         throw love::Exception(
@@ -218,12 +218,5 @@ bool TrueTypeRasterizer::GetConstant(Hinting in, const char*& out)
 
 std::vector<const char*> TrueTypeRasterizer::GetConstants(Hinting)
 {
-    auto entries = hintings.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return hintings.GetNames();
 }

--- a/source/modules/data/compressor/compressor.cpp
+++ b/source/modules/data/compressor/compressor.cpp
@@ -43,12 +43,5 @@ bool Compressor::GetConstant(Format in, const char*& out)
 
 std::vector<const char*> Compressor::GetConstants(Format)
 {
-    auto entries = formatNames.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return formatNames.GetNames();
 }

--- a/source/modules/data/datamodule.cpp
+++ b/source/modules/data/datamodule.cpp
@@ -235,14 +235,7 @@ bool DataModule::GetConstant(const char* in, data::ContainerType& out)
 
 std::vector<const char*> DataModule::GetConstants(data::ContainerType)
 {
-    auto entries = data::containers.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return data::containers.GetNames();
 }
 
 bool DataModule::GetConstant(const char* in, data::EncodeFormat& out)
@@ -257,12 +250,5 @@ bool DataModule::GetConstant(data::EncodeFormat in, const char*& out)
 
 std::vector<const char*> DataModule::GetConstants(data::EncodeFormat)
 {
-    auto entries = data::encoders.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return data::encoders.GetNames();
 }

--- a/source/modules/data/hashfunction/hashfunction.cpp
+++ b/source/modules/data/hashfunction/hashfunction.cpp
@@ -622,12 +622,5 @@ bool HashFunction::GetConstant(const Function& in, const char*& out)
 }
 std::vector<const char*> HashFunction::GetConstants(Function)
 {
-    auto entries = functionNames.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return functionNames.GetNames();
 }

--- a/source/modules/filesystem/filesystem.cpp
+++ b/source/modules/filesystem/filesystem.cpp
@@ -548,12 +548,5 @@ bool Filesystem::GetConstant(FileType in, const char*& out)
 
 std::vector<const char*> Filesystem::GetConstants(FileType)
 {
-    auto entries = fileTypes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return fileTypes.GetNames();
 }

--- a/source/modules/graphics/graphicsc.cpp
+++ b/source/modules/graphics/graphicsc.cpp
@@ -663,14 +663,7 @@ bool Graphics::GetConstant(DrawMode in, const char*& out)
 
 std::vector<const char*> Graphics::GetConstants(DrawMode)
 {
-    auto entries = drawModes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return drawModes.GetNames();
 }
 
 bool Graphics::GetConstant(const char* in, ArcMode& out)
@@ -685,14 +678,7 @@ bool Graphics::GetConstant(ArcMode in, const char*& out)
 
 std::vector<const char*> Graphics::GetConstants(ArcMode)
 {
-    auto entries = arcModes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return arcModes.GetNames();
 }
 
 bool Graphics::GetConstant(const char* in, BlendMode& out)
@@ -707,14 +693,7 @@ bool Graphics::GetConstant(BlendMode in, const char*& out)
 
 std::vector<const char*> Graphics::GetConstants(BlendMode)
 {
-    auto entries = blendModes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return blendModes.GetNames();
 }
 
 bool Graphics::GetConstant(const char* in, BlendAlpha& out)
@@ -729,14 +708,7 @@ bool Graphics::GetConstant(BlendAlpha in, const char*& out)
 
 std::vector<const char*> Graphics::GetConstants(BlendAlpha)
 {
-    auto entries = blendAlphaModes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return blendAlphaModes.GetNames();
 }
 
 bool Graphics::GetConstant(const char* in, StackType& out)
@@ -751,14 +723,7 @@ bool Graphics::GetConstant(StackType in, const char*& out)
 
 std::vector<const char*> Graphics::GetConstants(StackType)
 {
-    auto entries = stackTypes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return stackTypes.GetNames();
 }
 
 bool Graphics::GetConstant(const char* in, LineJoin& out)
@@ -773,14 +738,7 @@ bool Graphics::GetConstant(LineJoin in, const char*& out)
 
 std::vector<const char*> Graphics::GetConstants(LineJoin)
 {
-    auto entries = lineJoins.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return lineJoins.GetNames();
 }
 
 bool Graphics::GetConstant(const char* in, LineStyle& out)
@@ -795,12 +753,5 @@ bool Graphics::GetConstant(LineStyle in, const char*& out)
 
 std::vector<const char*> Graphics::GetConstants(LineStyle)
 {
-    auto entries = lineStyles.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return lineStyles.GetNames();
 }

--- a/source/modules/graphics/graphicsc.cpp
+++ b/source/modules/graphics/graphicsc.cpp
@@ -114,6 +114,15 @@ bool Graphics::SetMode(int width, int height)
 }
 
 /* Screen Stuff */
+void Graphics::SetActiveScreen(RenderScreen screen)
+{
+    Graphics::ACTIVE_SCREEN = screen;
+}
+
+const RenderScreen Graphics::GetActiveScreen() const
+{
+    return Graphics::ACTIVE_SCREEN;
+}
 
 const int Graphics::GetWidth(RenderScreen screen) const
 {

--- a/source/modules/graphics/graphicsc.cpp
+++ b/source/modules/graphics/graphicsc.cpp
@@ -113,6 +113,25 @@ bool Graphics::SetMode(int width, int height)
     return true;
 }
 
+/* Screen Stuff */
+
+const int Graphics::GetWidth(RenderScreen screen) const
+{
+    return Screen::Instance().GetWidth(screen);
+}
+
+const int Graphics::GetHeight() const
+{
+    return Screen::Instance().GetHeight();
+}
+
+std::vector<const char*> Graphics::GetScreens() const
+{
+    return Screen::Instance().GetConstants(Graphics::ACTIVE_SCREEN);
+}
+
+/* End Screen Stuff */
+
 Colorf Graphics::GetColor() const
 {
     return this->states.back().foreground;
@@ -619,46 +638,9 @@ constexpr auto lineStyles = BidirectionalMap<>::Create(
     "smooth", Graphics::LINE_SMOOTH,
     "rough",  Graphics::LINE_ROUGH
 );
-
-#if defined(__3DS__)
-/* "3D" Screens */
-#include "citro2d/graphics.h"
-constexpr auto screens = BidirectionalMap<>::Create(
-    "left",   Graphics::Screen::SCREEN_LEFT,
-    "right",  Graphics::Screen::SCREEN_RIGHT,
-    "bottom", Graphics::Screen::SCREEN_BOTTOM
-);
-#elif defined(__SWITCH__)
-#include "deko3d/graphics.h"
-constexpr auto screens = BidirectionalMap<>::Create(
-    "default", Graphics::Screen::SCREEN_DEFAULT
-);
-#endif
 // clang-format on
 
 /* Constants */
-
-bool Graphics::GetConstant(const char* in, Screen& out)
-{
-    return screens.Find(in, out);
-}
-
-bool Graphics::GetConstant(Screen in, const char*& out)
-{
-    return screens.ReverseFind(in, out);
-}
-
-std::vector<const char*> Graphics::GetConstants(Screen)
-{
-    auto entries = screens.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
-}
 
 bool Graphics::GetConstant(const char* in, DrawMode& out)
 {

--- a/source/modules/graphics/wrap_graphics.cpp
+++ b/source/modules/graphics/wrap_graphics.cpp
@@ -42,16 +42,18 @@ int Wrap_Graphics::GetScreens(lua_State* L)
     return 1;
 }
 
+/* Internal Screen Stuff */
+
 int Wrap_Graphics::GetActiveScreen(lua_State* L)
 {
+    RenderScreen screen = static_cast<RenderScreen>(0);
+    const char* name    = nullptr;
 
-    Graphics::Screen screen = static_cast<Graphics::Screen>(0);
-    const char* name        = nullptr;
+    if (name == nullptr)
+        screen = instance()->GetActiveScreen();
 
-    Luax::CatchException(L, [&]() { screen = instance()->GetActiveScreen(); });
-
-    if (!Graphics::GetConstant(screen, name))
-        return Luax::EnumError(L, "screen", Graphics::GetConstants(screen), name);
+    if (!Screen::GetConstant(screen, name))
+        return Luax::EnumError(L, "screen", Screen::GetConstants(screen), name);
 
     lua_pushstring(L, name);
 
@@ -60,37 +62,22 @@ int Wrap_Graphics::GetActiveScreen(lua_State* L)
 
 int Wrap_Graphics::SetActiveScreen(lua_State* L)
 {
-    Graphics::Screen screen = static_cast<Graphics::Screen>(0);
-    const char* name        = luaL_checkstring(L, 1);
+    RenderScreen screen = static_cast<RenderScreen>(0);
+    const char* name    = luaL_checkstring(L, 1);
 
-#if defined(__3DS__)
-    auto instance = (love::citro2d::Graphics*)instance();
-    if (instance->Get3D())
-    {
-        if (!Graphics::GetConstant(name, screen))
-            return Luax::EnumError(L, "screen", Graphics::GetConstants(screen), name);
-    }
-    else
-    {
-        if (!love::citro2d::Graphics::GetConstant(name, screen))
-            return Luax::EnumError(L, "screen", love::citro2d::Graphics::GetConstants(screen),
-                                   name);
-    }
-#elif defined(__SWITCH__)
-    if (!Graphics::GetConstant(name, screen))
-        return Luax::EnumError(L, "screen", Graphics::GetConstants(screen), name);
-#endif
+    if (!Screen::GetConstant(name, screen))
+        return Luax::EnumError(L, "screen", Screen::GetConstants(screen), name);
 
-    Luax::CatchException(L, [&]() { instance()->SetActiveScreen(screen); });
+    instance()->SetActiveScreen(screen);
 
     return 0;
 }
+/* End Internal Screen Stuff */
 
 int Wrap_Graphics::GetDimensions(lua_State* L)
 {
-    Graphics::Screen screen = static_cast<Graphics::Screen>(0);
-
-    const char* sname = lua_isnoneornil(L, 1) ? nullptr : luaL_checkstring(L, 1);
+    RenderScreen screen = static_cast<RenderScreen>(0);
+    const char* sname   = lua_isnoneornil(L, 1) ? nullptr : luaL_checkstring(L, 1);
 
     if (sname == nullptr)
         screen = instance()->GetActiveScreen();
@@ -103,16 +90,16 @@ int Wrap_Graphics::GetDimensions(lua_State* L)
 
 int Wrap_Graphics::GetWidth(lua_State* L)
 {
-    Graphics::Screen screen = static_cast<Graphics::Screen>(0);
+    RenderScreen screen = static_cast<RenderScreen>(0);
+    const char* sname   = lua_isnoneornil(L, 1) ? nullptr : luaL_checkstring(L, 1);
 
-    const char* sname = lua_isnoneornil(L, 1) ? nullptr : luaL_checkstring(L, 1);
-
+    /* getWidth should allow nil as a param */
     if (sname == nullptr)
         screen = instance()->GetActiveScreen();
     else
     {
-        if (!Graphics::GetConstant(sname, screen))
-            return Luax::EnumError(L, "screen", Graphics::GetConstants(screen), sname);
+        if (!Screen::GetConstant(sname, screen))
+            return Luax::EnumError(L, "screen", Screen::GetConstants(screen), sname);
     }
 
     lua_pushnumber(L, instance()->GetWidth(screen));
@@ -1362,6 +1349,30 @@ int Wrap_Graphics::Get3DDepth(lua_State* L)
     return 0;
 }
 
+int Wrap_Graphics::SetWide(lua_State* L)
+{
+#if defined(__3DS__)
+    bool enabled = Luax::ToBoolean(L, 1);
+
+    auto instance = (love::citro2d::Graphics*)instance();
+    instance->SetWide(enabled);
+#endif
+    return 0;
+}
+
+int Wrap_Graphics::GetWide(lua_State* L)
+{
+#if defined(__3DS__)
+    auto instance = (love::citro2d::Graphics*)instance();
+    bool enabled  = instance->GetWide();
+
+    Luax::PushBoolean(L, enabled);
+
+    return 1;
+#endif
+    return 0;
+}
+
 /* End Nintendo 3DS */
 
 int Wrap_Graphics::GetRendererInfo(lua_State* L)
@@ -1447,6 +1458,8 @@ static constexpr luaL_Reg functions[] =
     { "get3D",                 Wrap_Graphics::Get3D                 },
     { "get3DDepth",            Wrap_Graphics::Get3DDepth            },
     { "set3D",                 Wrap_Graphics::Set3D                 },
+    { "getWide",               Wrap_Graphics::GetWide               },
+    { "setWide",               Wrap_Graphics::SetWide               },
 #endif
     { 0,                       0                                    }
 };

--- a/source/modules/keyboard/keyboardc.cpp
+++ b/source/modules/keyboard/keyboardc.cpp
@@ -47,14 +47,7 @@ bool Keyboard::GetConstant(KeyboardOption in, const char*& out)
 
 std::vector<const char*> Keyboard::GetConstants(KeyboardOption)
 {
-    auto entries = keyboardOptions.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return keyboardOptions.GetNames();
 }
 
 const char* Keyboard::GetConstant(KeyboardOption in)

--- a/source/objects/box2d/body/body.cpp
+++ b/source/objects/box2d/body/body.cpp
@@ -639,12 +639,5 @@ bool Body::GetConstant(Body::Type in, const char*& out)
 
 std::vector<const char*> Body::GetConstants(Body::Type)
 {
-    auto entries = types.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return types.GetNames();
 }

--- a/source/objects/file/file.cpp
+++ b/source/objects/file/file.cpp
@@ -307,14 +307,7 @@ bool File::GetConstant(Mode in, const char*& out)
 
 std::vector<const char*> File::GetConstants(Mode mode)
 {
-    auto entries = modes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return modes.GetNames();
 }
 
 bool File::GetConstant(const char* in, BufferMode& out)
@@ -329,12 +322,5 @@ bool File::GetConstant(BufferMode in, const char*& out)
 
 std::vector<const char*> File::GetConstants(BufferMode mode)
 {
-    auto entries = bufferModes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return bufferModes.GetNames();
 }

--- a/source/objects/font/fontc.cpp
+++ b/source/objects/font/fontc.cpp
@@ -144,14 +144,7 @@ constexpr auto sharedFonts = BidirectionalMap<>::Create(
 
     std::vector<const char*> Font::GetConstants(AlignMode)
     {
-        auto entries = alignModes.GetEntries();
-        std::vector<const char*> ret;
-        ret.reserve(entries.second);
-        for (size_t i = 0; i < entries.second; i++)
-        {
-            ret.emplace_back(entries.first[i].first);
-        }
-        return ret;
+        return alignModes.GetNames();
     }
 
     bool Font::GetConstant(const char* in, Font::SystemFontType& out)
@@ -166,13 +159,6 @@ constexpr auto sharedFonts = BidirectionalMap<>::Create(
 
     std::vector<const char*> Font::GetConstants(Font::SystemFontType)
     {
-        auto entries = sharedFonts.GetEntries();
-        std::vector<const char*> ret;
-        ret.reserve(entries.second);
-        for (size_t i = 0; i < entries.second; i++)
-        {
-            ret.emplace_back(entries.first[i].first);
-        }
-        return ret;
+        return sharedFonts.GetNames();
     }
 } // namespace love::common

--- a/source/objects/imagedata/imagedata.cpp
+++ b/source/objects/imagedata/imagedata.cpp
@@ -150,8 +150,8 @@ void ImageData::Decode(Data* data)
     this->width  = decoded.width;
     this->height = decoded.height;
 #else
-    this->width  = decoded.subWidth;
-    this->height = decoded.subHeight;
+    this->width     = decoded.subWidth;
+    this->height    = decoded.subHeight;
 #endif
 
     this->data   = decoded.data;
@@ -565,12 +565,5 @@ bool ImageData::GetConstant(FormatHandler::EncodedFormat in, const char*& out)
 
 std::vector<const char*> ImageData::GetConstants(FormatHandler::EncodedFormat)
 {
-    auto entries = encodedFormats.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return encodedFormats.GetNames();
 }

--- a/source/objects/source/sourcec.cpp
+++ b/source/objects/source/sourcec.cpp
@@ -448,14 +448,7 @@ bool Source::GetConstant(Type in, const char*& out)
 
 std::vector<const char*> Source::GetConstants(Type)
 {
-    auto entries = types.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return types.GetNames();
 }
 
 /* Unit Constants */
@@ -472,12 +465,5 @@ bool Source::GetConstant(Unit in, const char*& out)
 
 std::vector<const char*> Source::GetConstants(Unit)
 {
-    auto entries = units.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return units.GetNames();
 }

--- a/source/objects/texture/texturec.cpp
+++ b/source/objects/texture/texturec.cpp
@@ -103,14 +103,7 @@ bool Texture::GetConstant(TextureType in, const char*& out)
 
 std::vector<const char*> Texture::GetConstants(Texture::TextureType)
 {
-    auto entries = texTypes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return texTypes.GetNames();
 }
 
 bool Texture::GetConstant(const char* in, FilterMode& out)
@@ -125,14 +118,7 @@ bool Texture::GetConstant(FilterMode in, const char*& out)
 
 std::vector<const char*> Texture::GetConstants(Texture::FilterMode)
 {
-    auto entries = filterModes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return filterModes.GetNames();
 }
 
 bool Texture::GetConstant(const char* in, WrapMode& out)
@@ -147,12 +133,5 @@ bool Texture::GetConstant(WrapMode in, const char*& out)
 
 std::vector<const char*> Texture::GetConstants(Texture::WrapMode)
 {
-    auto entries = wrapModes.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return wrapModes.GetNames();
 }

--- a/source/objects/transform/transform.cpp
+++ b/source/objects/transform/transform.cpp
@@ -117,12 +117,5 @@ bool Transform::GetConstant(MatrixLayout in, const char*& out)
 
 std::vector<const char*> Transform::GetConstants(MatrixLayout)
 {
-    auto entries = matrixLayouts.GetEntries();
-    std::vector<const char*> ret;
-    ret.reserve(entries.second);
-    for (size_t i = 0; i < entries.second; i++)
-    {
-        ret.emplace_back(entries.first[i].first);
-    }
-    return ret;
+    return matrixLayouts.GetNames();
 }


### PR DESCRIPTION
## Summary of the Pull Request
Splits up the logic for what screen (internally) is being rendered *properly*. This introduces the Screen class which handles all the necessary enums and functions to validate them. This also adds support for Wide Mode on Nintendo 3DS.

Thanks again to @fincs for the insights on Wide Mode.

## Validation Steps
Simply ran the binary with a Hello World app. For Wide Mode, the following main.lua was used:
```lua
function love.draw()
    local size = table.concat({love.graphics.getDimensions()}, "x")
    local data = table.concat({tostring(love.graphics.get3D()), tostring(love.graphics.getWide()), size}, "\n")

    love.graphics.print(data)
end

-- 3d mode is on by default
-- we could also do love.graphics.get3D() instead
local enable_depth, enable_wide = true, false
function love.gamepadpressed(joy, button)
    if button == "start" then
        love.event.quit()
    end

    if button == "leftshoulder" then
        enable_depth = not enable_depth
        love.graphics.set3D(enable_depth)
    elseif button == "rightshoulder" then
        enable_wide = not enable_wide
        love.graphics.setWide(enable_wide)
    end
end
```
The 3D and Wide modes both toggle appropriately. 3D/2D mode reports the proper screen sizes and Wide Mode returns `800x240` on the top screen.

## Checklist
- [x] Closes #NA
- [x] Successfully builds

## Screenshots
N/A
