### PR TITLE
Fixed static sources not looping

### DIFF
--- a/platform/3ds/source/objects/source.cpp
+++ b/platform/3ds/source/objects/source.cpp
@@ -165,6 +165,7 @@ void Source::PrepareAtomic()
     {
         case TYPE_STATIC:
             this->sources[0].data_pcm16 = (s16*)this->staticBuffer->GetBuffer();
+            this->sources[0].looping = this->looping;
             DSP_FlushDataCache(this->sources[0].data_pcm16, this->staticBuffer->GetSize());
             break;
         case TYPE_STREAM:


### PR DESCRIPTION
## Summary of the Pull Request
This little change fixes a bug where `static` audio sources wouldn't loop.
Solution by [piepie62,](https://github.com/piepie62) I just put the code in place.

## Validation Steps
1. Take any audio file, preferably a short one. I tried both MP3 and OGG, but it should be irrelevant.
2. Create a `Source` object from it and call `:setLooping(true)` on the source object.
3. Call `love.audio.play(your_source)`

Example lua code (`main.lua`):
```lua
function love.load()
    local staticSource = love.audio.newSource('assets/sfx/sound.ogg',"static")
    staticSource:setLooping(true)
    love.audio.play(staticSource)
end

function love.gamepadpressed(joystick, button)
    if button == "start" then
        love.event.quit()
    end
end
```

## Checklist
- [ ] Closes #N/A
- [x] Successfully builds

## Screenshots
N/A
