### PR TITLE
fix gamepad axis issues (3ds & wiiu)

### DIFF
--- a/platform/cafe/source/objects/gamepad.cpp
+++ b/platform/cafe/source/objects/gamepad.cpp
@@ -227,8 +227,7 @@ float Gamepad::GetGamepadAxis(GamepadAxis axis)
     if (!this->IsConnected())
         return 0.0f;
 
-    int getAxis = (int)axis;
-    return this->GetAxis(getAxis - 1);
+    return this->GetAxis(axis);
 }
 
 std::vector<float> Gamepad::GetAxes()

--- a/platform/cafe/source/objects/procontroller.cpp
+++ b/platform/cafe/source/objects/procontroller.cpp
@@ -217,8 +217,7 @@ float ProController::GetGamepadAxis(GamepadAxis axis)
     if (!this->IsConnected())
         return 0.0f;
 
-    int getAxis = (int)axis;
-    return this->GetAxis(getAxis - 1);
+    return this->GetAxis(axis);
 }
 
 std::vector<float> ProController::GetAxes()

--- a/platform/ctr/source/objects/joystick_ext.cpp
+++ b/platform/ctr/source/objects/joystick_ext.cpp
@@ -295,8 +295,7 @@ float Joystick<Console::CTR>::GetGamepadAxis(GamepadAxis axis)
     if (!this->IsConnected())
         return 0.0f;
 
-    int getAxis = (int)axis;
-    return this->GetAxis(getAxis - 1);
+    return this->GetAxis(axis);
 }
 
 bool Joystick<Console::CTR>::IsGamepadDown(const std::vector<GamepadButton>& buttons) const


### PR DESCRIPTION
## Summary of the Pull Request
Latest switch fix on joysticks introduced regression on 3ds and (I suppose) Wii U

## Validation Steps
Tested on 3ds only, I don't have a WiiU.

## Checklist
- [x ] Closes N/A
- [x] Successfully builds

## Screenshots
N/A
