### PR TITLE
minVolume defaults to 0.0 on audio Source instead of 1.0

### DIFF
--- a/include/objects/source/source.tcc
+++ b/include/objects/source/source.tcc
@@ -104,7 +104,7 @@ namespace love
         Source(SourceType type) :
             sourceType(type),
             looping(false),
-            minVolume(1.0f),
+            minVolume(0.0f),
             maxVolume(1.0f),
             volume(1.0f),
             valid(false),


### PR DESCRIPTION
## Summary of the Pull Request
Sets the default value of minVolume to 0.0 instead of 1.0 as in https://github.com/love2d/love/blob/main/src/modules/audio/openal/Source.h#L201

## Validation Steps
Tested on 3ds by changing volume with setVolume. Not tested on other platforms.

## Checklist
- [x] Closes N/A
- [x] Successfully builds

## Screenshots
N/A
