### PR TITLE
Bugfix/various gamepad issues

### DIFF
--- a/source/modules/love/scripts/callbacks.lua
+++ b/source/modules/love/scripts/callbacks.lua
@@ -225,11 +225,12 @@ end
 function love.run()
     if love.load then
         love.load(love.parsedGameArguments, love.rawGameArguments)
-        -- https://love2d.org/wiki/love.joystickadded
-        -- This callback is also triggered after love.load for every Joystick which was already connected when the game started up. 
-        for _, j in ipairs(love.joystick.getJoysticks()) do
-            love.handlers.joystickadded(j)
-        end
+    end
+
+    -- https://love2d.org/wiki/love.joystickadded
+    -- This callback is also triggered after love.load for every Joystick which was already connected when the game started up. 
+    for _, j in ipairs(love.joystick.getJoysticks()) do
+        love.handlers.joystickadded(j)
     end
 
     if love.timer then

--- a/source/modules/love/scripts/callbacks.lua
+++ b/source/modules/love/scripts/callbacks.lua
@@ -128,16 +128,16 @@ function love.createhandlers()
                 return love.gamepadaxis(joystick, axis, value)
             end
         end,
-        -- joystickadded = function(joystick)
-        --     if love.joystickadded then
-        --         return love.joystickadded(joystick)
-        --     end
-        -- end,
-        -- joystickremoved = function(joystick)
-        --     if love.joystickremoved then
-        --         return love.joystickremoved(joystick)
-        --     end
-        -- end,
+        joystickadded = function(joystick)
+            if love.joystickadded then
+                return love.joystickadded(joystick)
+            end
+        end,
+        joystickremoved = function(joystick)
+            if love.joystickremoved then
+                return love.joystickremoved(joystick)
+            end
+        end,
         focus = function(focused)
             if love.focus then
                 return love.focus(focused)
@@ -225,6 +225,11 @@ end
 function love.run()
     if love.load then
         love.load(love.parsedGameArguments, love.rawGameArguments)
+        -- https://love2d.org/wiki/love.joystickadded
+        -- This callback is also triggered after love.load for every Joystick which was already connected when the game started up. 
+        for _, j in ipairs(love.joystick.getJoysticks()) do
+            love.handlers.joystickadded(j)
+        end
     end
 
     if love.timer then

--- a/source/utilities/guid.cpp
+++ b/source/utilities/guid.cpp
@@ -20,7 +20,7 @@ static constexpr love::guid::GamepadInfo gamepadInfo[] =
     { 12,   8,  0, "Nintendo 3DS",                      "{B58A259A-13AA-46E0-BDCB-31898EDAB24E}", false, false }, // GAMEPAD_TYPE_NINTENDO_3DS
     { 12,  12,  0, "New Nintendo 3DS",                  "{7BC9702D-7D81-4EBB-AD4F-8C94076588D5}", true,  true  }, // GAMEPAD_TYPE_NEW_NINTENDO_3DS
     { 14,   6,  0, "Nintendo Switch",                   "{6EBE242C-820F-46E1-9A66-DC8200686D51}", true,  true  }, // GAMEPAD_TYPE_NINTENDO_SWITCH_HANDHELD
-    { 14,   6,  0, "Nintendo Switch Pro Controller",    "{42ECF5C5-AFA5-4EDE-B1A2-4E9C2287559A}", true,  false }, // GAMEPAD_TYPE_NINTENDO_SWITCH_PRO
+    { 14,   6,  0, "Nintendo Switch Pro Controller",    "{42ECF5C5-AFA5-4EDE-B1A2-4E9C2287559A}", true,  true  }, // GAMEPAD_TYPE_NINTENDO_SWITCH_PRO
     {  7,  12,  0, "Joy-Con L",                         "{660EBC7E-3953-4B74-8406-AD5992FCC5C7}", true,  false }, // GAMEPAD_TYPE_JOYCON_LEFT
     {  7,  12,  0, "Joy-Con R",                         "{AD770831-A7E4-41A8-8DD0-FD48323E0043}", false, true  }, // GAMEPAD_TYPE_JOYCON_RIGHT
     { 14,  18,  0, "Joy-Con Pair",                      "{701B198B-9AD9-4730-8EEB-EBECF707B9DF}", true,  true  }, // GAMEPAD_TYPE_JOYCON_PAIR


### PR DESCRIPTION
## Summary of the Pull Request
- fix Nintendo switch pro controller configuration (hasZr flag)
- readded joystickadded/joystickremoved callbacks (crashed if joystick was added or removed)
- call joystickadded on load for all connected gamepads (as mentioned in the notes of https://love2d.org/wiki/love.joystickadded)

## Validation Steps
Tested on switch & 3ds

## Checklist
- [x] Closes N/A
- [x] Successfully builds

## Screenshots
N/A