### PR TITLE
fix: TempTransform pushing to stack twice

### DIFF
--- a/include/utilities/temptransform.hpp
+++ b/include/utilities/temptransform.hpp
@@ -33,7 +33,6 @@ namespace love
 
         ~TempTransform()
         {
-            printf("[TempTransform::~TempTransform] Popping tempTransform\n");
             this->graphics->PopTransform();
         }
 

--- a/include/utilities/temptransform.hpp
+++ b/include/utilities/temptransform.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <stdio.h>
 #include <modules/graphics_ext.hpp>
 
 namespace love
@@ -15,7 +15,6 @@ namespace love
         TempTransform(Graphics<Console::Which>& graphics, const Matrix4& transform) :
             TempTransform(graphics)
         {
-            this->graphics->PushTransform();
             this->graphics->InternalScale(transform);
         }
 
@@ -35,6 +34,7 @@ namespace love
 
         ~TempTransform()
         {
+            printf("[TempTransform::~TempTransform] Popping tempTransform\n");
             this->graphics->PopTransform();
         }
 

--- a/include/utilities/temptransform.hpp
+++ b/include/utilities/temptransform.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <stdio.h>
 #include <modules/graphics_ext.hpp>
 
 namespace love


### PR DESCRIPTION
## Summary of the Pull Request
This fixes a problem with SpriteBatches where they would work incorrectly with transform objects. The issue turned out to be even worse than initially thought: the `TempTransform(graphics, transform)` constructor called `graphics->PushTransform()` **twice**, causing the transform stack to leak.

## Validation Steps
Just print-debugging the `TempTransform` constructors led me to discovering that there were more pushes to the transformStack than pops.

## Checklist
- [ ] Closes N/A
- [x] Successfully builds

## Screenshots
Before:
![2025-08-06_12-23-24 579_top](https://github.com/user-attachments/assets/1cb9fcd6-3297-485b-8b2c-85b25a77c3f4)
<img width="501" height="227" alt="image" src="https://github.com/user-attachments/assets/065e34e7-3b08-4e7d-a878-b712b31b3ee3" />


After:
![2025-08-06_12-18-42 856_top](https://github.com/user-attachments/assets/d1478695-a9a7-4493-ab6c-ea98a15f8e16)
<img width="455" height="189" alt="image" src="https://github.com/user-attachments/assets/34270528-08cc-4a2f-8232-53eafe16a032" />
