### PR TITLE
Load the game from romfs:/ when running as an installed title (CIA/NRO)

### DIFF
--- a/source/modules/filesystem/physfs/filesystem.cpp
+++ b/source/modules/filesystem/physfs/filesystem.cpp
@@ -139,11 +139,16 @@ void Filesystem::Init(const char* arg0)
 {
     this->executablePath = getApplicationPath(arg0);
 
-    /* should only happen on Wii U */
-    if (this->executablePath.empty())
+    /* On Wii U an empty path is a real error (cannot locate the running .wuhb),
+       so keep the original behavior there. */
+    if (this->executablePath.empty() && love::Console::Is(love::Console::CAFE))
         throw love::Exception("Failed to get executable path.");
 
-    if (!PHYSFS_init(this->executablePath.c_str()))
+    /* Installed title (3DS CIA / Switch NRO): arg0 is empty or a placeholder, so
+       PHYSFS_init(exepath) fails. Retry with nullptr (best-effort base dir) so the
+       game can still be mounted -- from romfs:/ in that case (see boot.lua). */
+    const char* base = this->executablePath.empty() ? nullptr : this->executablePath.c_str();
+    if (!PHYSFS_init(base) && !PHYSFS_init(nullptr))
         throw love::Exception("Failed to initialize filesystem: %s", Filesystem::GetLastError());
 
     PHYSFS_setWriteDir(nullptr);

--- a/source/modules/love/scripts/boot.lua
+++ b/source/modules/love/scripts/boot.lua
@@ -60,6 +60,8 @@ function love.boot()
 
     -- Is this one of those fancy "fused" games?
     local can_has_game = pcall(love.filesystem.setSource, exepath)
+    -- Installed title (CIA/NRO): no fused game on a file path -> use romfs:/
+    if not can_has_game then can_has_game = pcall(love.filesystem.setSource, "romfs:/") end
 
     -- It's a fused game, don't parse --game argument
     if can_has_game then


### PR DESCRIPTION
As an installed title, the Home Menu passes no argv0 -- on 3DS a placeholder
("embedded boot.lua") arrives. Filesystem::Init then calls PHYSFS_init() with that
invalid path, which fails, so Init throws before boot.lua runs and the app opens
and immediately closes with no screen. Also, nothing mounts romfs:/ as the game
source (the engine reads its own romfs via direct stdio only).

- Filesystem::Init: retry PHYSFS_init(nullptr) if the exepath-based init fails,
  instead of aborting.
- boot.lua: if there is no fused game on a file path, mount the source from romfs:/.

This lets a game be packaged as a native, installable .cia (game placed in the
title's RomFS) instead of only a .3dsx. Verified on a 3DS (Luma CFW): a
makerom-built .cia with the game in RomFS boots and runs.

## Summary of the Pull Request
Enables running a LÖVE Potion game as an **installed title** (`.cia` on 3DS / `.nro`
on Switch) by loading the game from `romfs:/`. Today the framework only loads a game
that is fused into the executable file; an installed title has no such file, so any
CIA opens and immediately closes.

Two minimal, isolated changes:
- **`source/modules/filesystem/physfs/filesystem.cpp` (`Filesystem::Init`)** — retry
  `PHYSFS_init(nullptr)` when init with the (empty/placeholder) executable path fails,
  instead of aborting.
- **`source/modules/love/scripts/boot.lua`** — fall back to
  `love.filesystem.setSource("romfs:/")` when there is no fused game on a file path.

**No behavior change for `.3dsx`/fused games** (the executable path is non-empty, so
neither fallback triggers). **Wii U is unchanged**: the original empty-path error is
kept, guarded to `Console::CAFE` (the retry only affects 3DS/Switch installed titles).

## Validation Steps
Built and tested on real hardware (Old 3DS, Luma3DS CFW).

**1. Build the patched framework as usual:**
```
catnip -T 3DS -DLIBRARY_LOADER=linktime -DUSE_CURL_BACKEND=ON
```
This produces `build/main.release/lovepotion.elf` and the engine RomFS at
`platform/ctr/romfs/` (`shaders/`, `nogame/`).

**2. Assemble a RomFS = engine romfs + your game at the root.** Minimal test game
`romfs/main.lua`:
```lua
function love.draw()
    love.graphics.print("CIA romfs OK", 8, 8)
end
```
So `romfs/` contains `shaders/`, `nogame/`, and `main.lua`.

**3. Build a fake-signed CIA with makerom (installable on CFW):**
```
smdhtool --create "RomfsTest" "romfs test" "author" icon48.png app.smdh
makerom -f cia -o test.cia -elf build/main.release/lovepotion.elf \
  -rsf app.rsf -icon app.smdh -target t -ignoresign \
  -DAPP_ROMFS=romfs -DAPP_TITLE="RomfsTest" -DAPP_UNIQUE_ID=0xF8001
```
`app.rsf` is a standard homebrew RSF with `TitleInfo.Category: Application`,
`RomFs.RootPath: $(APP_ROMFS)`, and the usual `ServiceAccessControl` for a
graphics/audio app.

**4. Install `test.cia` via FBI and launch it from the Home Menu.** It boots and runs
the game from RomFS (`CIA romfs OK`) instead of closing back to Home.

Without this PR, step 4 opens and immediately closes -- `Filesystem::Init` throws on
the placeholder path before `boot.lua` ever runs.

A full working, Dockerized pipeline (patched build + makerom + RSF) that produced and
validated this is here: https://github.com/rafarvns/cap-goal-3ds/tree/main/tools/cia

## Checklist
- [x] Closes N/A
- [x] Successfully builds

## Screenshots
_(3DS running the game installed as a `.cia` -- attach a photo if handy; otherwise N/A.)_
